### PR TITLE
Feat: Add update checker in Invoke-CIPPPreFlightCheck

### DIFF
--- a/CIPPAPIModule/private/Invoke-CIPPPreFlightCheck.ps1
+++ b/CIPPAPIModule/private/Invoke-CIPPPreFlightCheck.ps1
@@ -1,20 +1,43 @@
 <#
 .SYNOPSIS
-    Invokes the pre-flight check before connecting to the CIPP API.
+    Performs necessary checks before making CIPP API calls.
 
 .DESCRIPTION
-    This function performs a pre-flight check before connecting to the CIPP API. It checks if the required CIPP API information is available and if the token has expired. If the information is not found or the token has expired, it connects to the CIPP API using the provided credentials.
+    The Invoke-CIPPPreFlightCheck function validates that all required CIPP API connection 
+    variables are set, checks for module updates, and ensures the authentication token is valid.
 
-.PARAMETER None
-    This function does not accept any parameters.
+    If the authentication token is missing or expired, it automatically attempts to reconnect 
+    to the CIPP API using the stored credentials.
+    
+    This function should be called before any API operation to ensure proper connectivity.
+
+.PARAMETER SkipVersionCheck
+    When specified, bypasses the check for module updates. This can be useful in automated scenarios
+    or when you want to avoid the potential delay of version checking.
 
 .EXAMPLE
     Invoke-CIPPPreFlightCheck
+    
+    Performs all pre-flight checks including module update verification.
 
+.EXAMPLE
+    Invoke-CIPPPreFlightCheck -SkipVersionCheck
+    Performs pre-flight checks but skips checking for module updates.
+    
+.NOTES
+    This function requires that Set-CIPPAPIDetails has been previously run to set up the 
+    connection information (ClientID, ClientSecret, APIURL, and TenantID).
+    
+    An error will be thrown if required connection variables are missing.
+
+.OUTPUTS
+    None. This function does not generate any output.
 #>
 function Invoke-CIPPPreFlightCheck {
     [CmdletBinding()]
-    param ()
+    param (
+        [switch]$SkipVersionCheck
+    )
     if ($null -eq $Script:CIPPClientID -or 
         $null -eq $Script:CIPPClientSecret -or 
         $null -eq $Script:CIPPAPIUrl -or 
@@ -22,6 +45,13 @@ function Invoke-CIPPPreFlightCheck {
         throw 'Cannot continue: CIPP API information not found. Please run Set-CIPPAPIDetails before connecting to the API.'
         break
     }
+
+    # Check for module updates
+    if ($SkipVersionCheck.IsPresent -eq $false) {
+        Test-CIPPAPIModuleUpdate
+    }
+
+    # Check token expiry
     Get-TokenExpiry
     if ((-not $Script:ExpiryDateTime) -or ($script:ExpiryDateTime -lt (Get-Date))) {
         Write-Verbose 'Token expired or not found. Connecting to CIPP'

--- a/CIPPAPIModule/private/Test-CIPPAPIModuleUpdate.ps1
+++ b/CIPPAPIModule/private/Test-CIPPAPIModuleUpdate.ps1
@@ -1,0 +1,110 @@
+﻿<#
+.SYNOPSIS
+    Checks if there's a newer version of the CIPPAPIModule available on the PowerShell Gallery.
+
+.DESCRIPTION
+    The Test-CIPPAPIModuleUpdate function compares the locally installed version of CIPPAPIModule 
+    with the latest version available on the PowerShell Gallery. It determines the local version 
+    by either reading the module manifest or querying the installed modules. If a newer version 
+    is found, it displays a warning message suggesting an update.
+
+.EXAMPLE
+    Test-CIPPAPIModuleUpdate
+    
+    Checks if the locally installed CIPPAPIModule is up to date.
+
+.EXAMPLE
+    Test-CIPPAPIModuleUpdate -Verbose
+    
+    Checks for updates with verbose output, showing the local and gallery versions.
+
+.NOTES
+    This function requires internet access to query the PowerShell Gallery.
+    It handles various error scenarios gracefully, including network errors, 
+    manifest access errors, and version parsing issues.
+
+.LINK
+    Update-Module
+#>
+# Function to check for CIPPAPIModule updates
+function Test-CIPPAPIModuleUpdate {
+    [CmdletBinding()]
+    param ()
+    Write-Verbose 'Checking for CIPPAPIModule updates...'
+    $moduleName = 'CIPPAPIModule'
+    # Get the path to the module manifest within the currently executing script's module directory
+    # Assumes Invoke-CIPPPreFlightCheck.ps1 is in the 'private' folder, so go up one level.
+    $moduleManifestPath = Join-Path $PSScriptRoot '..\CIPPAPIModule.psd1'
+
+    if (-not (Test-Path $moduleManifestPath)) {
+        Write-Warning "Could not find module manifest at expected location: $moduleManifestPath. Cannot determine local version."
+        # Attempt to get from installed modules as a fallback
+        $installedModule = Get-InstalledModule -Name $moduleName -ErrorAction SilentlyContinue
+        if (-not $installedModule) {
+            Write-Warning "Module '$moduleName' also not found via Get-InstalledModule. Cannot check for updates."
+            return
+        }
+        # Ensure Version object exists before accessing ToString()
+        if ($installedModule.Version) {
+            $localVersionString = $installedModule.Version.ToString()
+        } else {
+            Write-Warning "Module '$moduleName' found via Get-InstalledModule, but version information is missing. Cannot check for updates."
+            return
+        }
+    } else {
+        try {
+            # Read the version directly from the manifest file using Import-PowerShellDataFile for safety
+            $manifestData = Import-PowerShellDataFile -Path $moduleManifestPath
+            $localVersionString = $manifestData.ModuleVersion
+        } catch {
+            Write-Warning "Error reading module manifest at '$moduleManifestPath': $($_.Exception.Message). Cannot determine local version."
+            return
+        }
+    }
+
+
+    if (-not $localVersionString) {
+        Write-Warning "Could not determine the local version of '$moduleName'. Cannot check for updates."
+        return
+    }
+    
+    # Ensure the version string is in a valid format
+    try {
+        $localVersion = [version]$localVersionString
+        Write-Verbose "Local CIPPAPIModule version: $localVersion"
+    } catch {
+        Write-Warning "Local version string '$localVersionString' from manifest is not a valid version format. Error: $($_.Exception.Message). Cannot check for updates."
+        return
+    }
+
+
+    try {
+        # Find the module in the gallery
+        Write-Verbose "Querying PowerShell Gallery for the latest version of $moduleName..."
+        # Specify repository to avoid potential conflicts if multiple sources are registered
+        $galleryModule = Find-Module -Name $moduleName -Repository PSGallery -ErrorAction Stop
+        $galleryVersion = $galleryModule.Version
+
+        Write-Verbose "Latest version on PSGallery: $galleryVersion"
+
+        # Compare versions
+        if ($galleryVersion -gt $localVersion) {
+            Write-Host '---------------------------------------------------------------------' -ForegroundColor Yellow
+            Write-Host "WARNING: A newer version of CIPPAPIModule (v$galleryVersion) is available." -ForegroundColor Yellow
+            Write-Host "You are currently running v$localVersion." -ForegroundColor Yellow
+            Write-Host "Consider running 'Update-Module $moduleName' to get the latest features and fixes." -ForegroundColor Yellow
+            Write-Host '---------------------------------------------------------------------' -ForegroundColor Yellow
+        } else {
+            Write-Verbose "CIPPAPIModule is up to date (v$localVersion)."
+        }
+    } catch [System.Net.WebException] {
+        # Catch specific network errors
+        Write-Warning "Network error: Failed to connect to the PowerShell Gallery to check for $moduleName updates. Please check your internet connection. Error: $($_.Exception.Message)"
+    } catch [Microsoft.PowerShell.Commands.ModuleNotFoundException] {
+        # Catch if Find-Module specifically fails to find the module
+        Write-Warning "'$moduleName' not found on the PowerShell Gallery (PSGallery). Cannot check for updates."
+    } catch {
+        # Catch any other errors during Find-Module or version comparison
+        Write-Warning "An error occurred while checking for $moduleName updates on the PowerShell Gallery: $($_.Exception.Message)"
+    }
+}


### PR DESCRIPTION
Implement a pre-flight check for module updates in the Invoke-CIPPPreFlightCheck function. This feature compares the locally installed version of the CIPPAPIModule with the latest version available on the PowerShell Gallery. If an update is available, a warning message is displayed, encouraging users to update for the latest features and fixes. The addition of a `-SkipVersionCheck` parameter allows users to bypass this check when necessary.

Fixes #46