### PR TITLE
Change AssignTo parameter type to boolean and update default Language value

### DIFF
--- a/CIPPAPIModule/public/Endpoint/Autopilot/New-CIPPAutopilotConfig.ps1
+++ b/CIPPAPIModule/public/Endpoint/Autopilot/New-CIPPAutopilotConfig.ps1
@@ -87,7 +87,7 @@ function New-CIPPAutopilotConfig {
         [bool]$SharedDevice = $false,
         
         [Parameter(Mandatory = $false)]
-        [string]$AssignTo,
+        [bool]$AssignTo,
         
         [Parameter(Mandatory = $false)]
         [string]$DeviceNameTemplate,
@@ -111,7 +111,7 @@ function New-CIPPAutopilotConfig {
         [bool]$AutoKeyboard = $false,
         
         [Parameter(Mandatory = $false)]
-        [string]$Language = 'en-US'
+        [string]$Language = 'os-default'
     )
 
     Write-Verbose "Creating Autopilot configuration for $($CustomerTenantID.Count) tenant(s)"


### PR DESCRIPTION
Update the AssignTo parameter to a boolean type and set the default Language value to 'os-default'.