### PR TITLE
Fix: Fix client_id parameter issue in API requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,173 @@
+# AGENTS.md - CIPPAPIModule Development Guidelines
+
+Guidelines for AI coding agents working on this PowerShell module for the CIPP API.
+
+## Project Info
+
+- **Language**: PowerShell 7.0+
+- **Build**: ModuleBuilder
+- **License**: GNU AGPL v3
+- **Repo**: https://github.com/BNWEIN/CIPPAPIModule/
+
+## Build & Test Commands
+
+```powershell
+# Install dependencies and build
+Install-Module ModuleBuilder -Force
+Build-Module -SemVer "1.0.0"
+
+# Import for testing (from source)
+Import-Module ./CIPPAPIModule/CIPPAPIModule.psd1 -Force
+
+# Test manually
+Set-CIPPAPIDetails -CIPPClientID "id" -CIPPClientSecret "secret" `
+                   -CIPPAPIUrl "https://your-cipp.azurewebsites.net" -TenantID "tenant"
+Test-CIPPApiConnection
+Get-CIPPUsers -CustomerTenantID "tenant-guid"
+```
+
+No automated tests exist. CI/CD triggers on git tags and publishes to PowerShell Gallery.
+
+## Project Structure
+
+```
+CIPPAPIModule/
+├── CIPPAPIModule/
+│   ├── CIPPAPIModule.psd1      # Module manifest (don't edit version)
+│   ├── CIPPAPIModule.psm1      # Auto-loads all .ps1 files
+│   ├── private/                # Internal helpers (not exported)
+│   └── public/                 # Exported functions (286+ files)
+│       ├── Identity/Administration/{Users,Groups,Devices}/
+│       ├── Email/{Administration,Transport,Spamfilter}/
+│       ├── Endpoint/{Applications,Autopilot,MEM}/
+│       ├── Security/{Defender,Incidents}/
+│       ├── Tenant/{Administration,Conditional,GDAP}/
+│       └── CIPP/{Core,Scheduler,Settings}/
+├── Docs/                       # Auto-generated help docs
+└── build.psd1                  # ModuleBuilder config
+```
+
+## Function Template
+
+```powershell
+<#
+.SYNOPSIS
+    Brief description.
+.DESCRIPTION
+    Detailed description.
+.PARAMETER CustomerTenantID
+    The tenant ID to operate on.
+.EXAMPLE
+    Get-CIPPExample -CustomerTenantID "guid"
+#>
+function Verb-CIPPNoun {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$OptionalParam
+    )
+
+    Write-Verbose "Descriptive action message"
+
+    $endpoint = '/api/EndpointName'
+    $params = @{
+        tenantFilter = $CustomerTenantID
+    }
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}
+```
+
+## Naming Conventions
+
+| Type              | Pattern                    | Example                           |
+| ----------------- | -------------------------- | --------------------------------- |
+| Public functions  | `Verb-CIPPNoun`            | `Get-CIPPUsers`, `Add-CIPPUser`   |
+| Private functions | `Verb-Noun` (no CIPP)      | `Connect-CIPP`, `Get-TokenExpiry` |
+| Parameters        | PascalCase                 | `$CustomerTenantID`, `$UserID`    |
+| Tenant param      | Always `$CustomerTenantID` | Required for most functions       |
+
+**Approved verbs**: Get, Set, Add, Remove, New, Clear, Convert, Invoke, Test, Start, Restore, Sync, Send, Reset, Revoke
+
+## API Call Patterns
+
+**GET request:**
+
+```powershell
+$endpoint = '/api/ListSomething'
+$params = @{
+    tenantFilter = $CustomerTenantID
+    userId       = $UserID
+}
+Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+```
+
+**POST request:**
+
+```powershell
+$endpoint = '/api/AddSomething'
+$body = @{
+    tenantFilter = $CustomerTenantID
+    displayName  = $DisplayName
+}
+Invoke-CIPPRestMethod -Endpoint $endpoint -Body $body -Method 'POST'
+```
+
+## Code Style
+
+- **Indentation**: 4 spaces
+- **Braces**: Opening brace on same line
+- **Hashtables**: One key-value per line
+- **Parameters**: Always specify `[Parameter(Mandatory = $true|$false)]`
+- **Comment-based help**: Required for all public functions
+
+## Script Variables (Module State)
+
+```powershell
+$script:CIPPClientID      # OAuth client ID
+$script:CIPPClientSecret  # OAuth client secret
+$script:CIPPAPIUrl        # API base URL
+$script:TenantID          # Azure AD tenant
+$script:AuthHeader        # Current auth headers
+$script:ExpiryDateTime    # Token expiry time
+```
+
+## Common Patterns
+
+**Optional parameters:**
+
+```powershell
+$optionalParams = @{ City = $City; Department = $Department }
+foreach ($key in $optionalParams.Keys) {
+    if ($optionalParams[$key]) { $body[$key] = $optionalParams[$key] }
+}
+```
+
+**Scheduled tasks:**
+
+```powershell
+Scheduled = @{
+    enabled = $ScheduledFor -ne $null
+    date    = if ($ScheduledFor) {
+        ([System.DateTimeOffset]$ScheduledFor).ToUnixTimeSeconds()
+    } else { $null }
+}
+```
+
+## Adding New Functions
+
+1. Create `.ps1` file in appropriate `public/` subdirectory
+2. Include full comment-based help (.SYNOPSIS, .DESCRIPTION, .PARAMETER, .EXAMPLE)
+3. Use `Invoke-CIPPRestMethod` for API calls
+4. Add `Write-Verbose` for debugging
+5. Module loader auto-imports all `.ps1` files
+
+## Important Notes
+
+- `Invoke-CIPPRestMethod` handles auth via `Invoke-CIPPPreFlightCheck`
+- Module auto-refreshes expired OAuth tokens
+- Don't manually edit `ModuleVersion` in manifest (set by CI build)
+- Keep functions focused on a single CIPP API endpoint
+- Follow patterns from similar existing functions

--- a/CIPPAPIModule/private/Connect-CIPP.ps1
+++ b/CIPPAPIModule/private/Connect-CIPP.ps1
@@ -24,20 +24,20 @@ Connects to the CIPP API using the specified credentials.
 #>
 function Connect-CIPP {
     [CmdletBinding()]
-    Param(
+    param(
         [string]$CIPPAPIUrl,
         [string]$CIPPClientID,
         [string]$CIPPClientSecret,
         [string]$TenantID
     )
 
-    $Script:AuthBody = @{
-        client_id     = $script:CIPPClientID
-        client_secret = $script:CIPPClientSecret
-        scope         = "api://$($script:CIPPClientID)/.default"
+    $AuthBody = @{
+        client_id     = $CIPPClientID
+        client_secret = $CIPPClientSecret
+        scope         = "api://$($CIPPClientID)/.default"
         grant_type    = 'client_credentials'
     }
-    $token = Invoke-RestMethod -Uri "https://login.microsoftonline.com/$script:TenantId/oauth2/v2.0/token" -Method POST -Body $AuthBody
+    $token = Invoke-RestMethod -Uri "https://login.microsoftonline.com/$TenantID/oauth2/v2.0/token" -Method POST -Body $AuthBody
 
     $script:AuthHeader = @{ Authorization = "Bearer $($token.access_token)" }
     $script:TokenAcquiredTime = Get-Date

--- a/CIPPAPIModule/public/Set-CIPPAPIDetails.ps1
+++ b/CIPPAPIModule/public/Set-CIPPAPIDetails.ps1
@@ -1,40 +1,65 @@
 <#
 .SYNOPSIS
-Sets the CIPP API details.
+    Sets the CIPP API connection details and validates the module version.
 
 .DESCRIPTION
-The Set-CIPPAPIDetails function is used to set the CIPP API details, including the client ID, client secret, API URL, and tenant ID.
+    The Set-CIPPAPIDetails function is used to configure the CIPP API connection details, 
+    including the client ID, client secret, API URL, and tenant ID. These credentials are 
+    stored in script-scoped variables for use by all subsequent API operations.
+    
+    This function also performs a module update check during initialization to alert users 
+    if a newer version of CIPPAPIModule is available on the PowerShell Gallery. This check 
+    occurs once during setup rather than on every API call for optimal performance.
 
 .PARAMETER CIPPClientID
-Specifies the client ID for the CIPP API.
+    Specifies the client ID for the CIPP API application registration.
 
 .PARAMETER CIPPClientSecret
-Specifies the client secret for the CIPP API.
+    Specifies the client secret for the CIPP API application registration.
 
 .PARAMETER CIPPAPIUrl
-Specifies the URL for the CIPP API.
+    Specifies the base URL for the CIPP API endpoint.
 
 .PARAMETER TenantID
-Specifies the tenant ID for the CIPP API.
+    Specifies the Azure AD tenant ID used for OAuth authentication.
+
+.PARAMETER SkipVersionCheck
+    When specified, bypasses the module update check during initialization. Use this 
+    parameter in automated scenarios where version checking should be deferred or skipped.
 
 .EXAMPLE
-Set-CIPPAPIDetails -CIPPClientID "d8d41058-97df-4b80-8e1b-7083d756409f" -CIPPClientSecret "YourSecurePassword" -CIPPAPIUrl "https://api.cipp.com" -TenantID "7c2f78c0-554e-4f42-a663-c4df3ce7f51f"
+    Set-CIPPAPIDetails -CIPPClientID "d8d41058-97df-4b80-8e1b-7083d756409f" -CIPPClientSecret "YourSecurePassword" -CIPPAPIUrl "https://api.cipp.com" -TenantID "7c2f78c0-554e-4f42-a663-c4df3ce7f51f"
 
-This example sets the CIPP API details with the specified values.
+    This example sets the CIPP API details with version checking enabled.
 
+.EXAMPLE
+    Set-CIPPAPIDetails -CIPPClientID "d8d41058-97df-4b80-8e1b-7083d756409f" -CIPPClientSecret "YourSecurePassword" -CIPPAPIUrl "https://api.cipp.com" -TenantID "7c2f78c0-554e-4f42-a663-c4df3ce7f51f" -SkipVersionCheck
+
+    This example sets the CIPP API details while skipping the module version check.
+
+.NOTES
+    After running this function, you can use other CIPPAPIModule functions to interact 
+    with the CIPP API. The credentials are stored in the current PowerShell session and 
+    will be lost when the session is closed.
 #>
 function Set-CIPPAPIDetails {
     [CmdletBinding()]
-    Param(
-        [Parameter(ParameterSetName = 'CIPP', Mandatory = $true)]
+    param(
+        [Parameter(Mandatory = $true)]
         [string]$CIPPClientID,
-        [Parameter(ParameterSetName = 'CIPP', Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [String]$CIPPClientSecret,
-        [Parameter(ParameterSetName = 'CIPP', Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [String]$CIPPAPIUrl,
-        [Parameter(ParameterSetName = 'CIPP', Mandatory = $true)]
-        [String]$TenantID
+        [Parameter(Mandatory = $true)]
+        [String]$TenantID,
+        [switch]$SkipVersionCheck
     )
+    
+    if ($SkipVersionCheck.IsPresent -eq $false) {
+        Test-CIPPAPIModuleUpdate
+    }
+
     Write-Verbose 'Setting CIPP API Keys'
     $script:CIPPClientID = $CIPPClientID
     $script:CIPPClientSecret = $CIPPClientSecret


### PR DESCRIPTION
Update the authentication process to ensure the client_id is correctly passed in all API requests, resolving the 'AADSTS900144' error. Standardize parameter usage across functions for clarity and performance, and introduce documentation for development guidelines.

Fixes #75