### PR TITLE
Updated help info for Set-CIPPExecCPVPerms

### DIFF
--- a/CIPPAPIModule/public/CIPP/Core/Set-CIPPExecCPVPerms.ps1
+++ b/CIPPAPIModule/public/CIPP/Core/Set-CIPPExecCPVPerms.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-Sets the CPV (Customer Provided Values) permissions for a specific customer tenant.
+Sets the CPV (Control Panel Vendor) permissions for a specific customer tenant.
 
 .DESCRIPTION
 The Set-CIPPExecCPVPerms function is used to refresh the CPV permissions for a specified customer tenant. It calls the Invoke-CIPPRestMethod function internally to make the REST API call.
@@ -9,15 +9,15 @@ The Set-CIPPExecCPVPerms function is used to refresh the CPV permissions for a s
 Specifies the ID of the customer tenant for which the CPV permissions need to be refreshed. This parameter is mandatory.
 
 .PARAMETER ResetSP
-Specifies whether to reset the Stored Procedure (SP) associated with the CPV permissions. The valid values are "true" and "false". This parameter is optional and defaults to "false".
+Specifies whether delete the Service Principal (SP) associated with the CPV permissions and re-add it. The valid values are "true" and "false". This parameter is optional and defaults to "false".
 
 .EXAMPLE
 Set-CIPPExecCPVPerms -CustomerTenantID "12345678-1234-1234-1234-1234567890AB" -ResetSP "true"
-Refreshes the CPV permissions for the customer tenant with the ID "12345678-1234-1234-1234-1234567890AB" and resets the associated Stored Procedure.
+Refreshes the CPV permissions for the customer tenant with the ID "12345678-1234-1234-1234-1234567890AB" and resets the associated Service Principal.
 
 .EXAMPLE
 Set-CIPPExecCPVPerms -CustomerTenantID "87654321-4321-4321-4321-0987654321BA"
-Refreshes the CPV permissions for the customer tenant with the ID "87654321-4321-4321-4321-0987654321BA" without resetting the associated Stored Procedure.
+Refreshes the CPV permissions for the customer tenant with the ID "87654321-4321-4321-4321-0987654321BA" without resetting the associated Service Principal.
 #>
 function Set-CIPPExecCPVPerms {
     [CmdletBinding()]


### PR DESCRIPTION
CPV to Control Panel Vendor from Customer Provided Values
SP to Service Principal from Stored Procedure
Clarified that Reset means to delete and re-add. This is the language used in CIPP for the reset task.