### PR TITLE
Update set sipp exec cpv perms bug

### DIFF
--- a/CIPPAPIModule/public/CIPP/Settings/Set-CIPPExcludeTenant.ps1
+++ b/CIPPAPIModule/public/CIPP/Settings/Set-CIPPExcludeTenant.ps1
@@ -48,20 +48,20 @@ function Set-CIPPExcludeTenant {
     $endpoint = '/api/execexcludetenant'
 
     if ($RemoveExclusion) {
+        Write-Verbose "Removing Tenant $CustomerTenantID from the exclusion list."
         $params = @{
-            TenantFilter    = $CustomerTenantID
             RemoveExclusion = $true
         }
-        Write-Verbose "Removing Tenant $CustomerTenantID from the exclusion list."
-        Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
     } else {
+		Write-Verbose "Adding Tenant $CustomerTenantID to the exclusion list."    
         $params = @{
             AddExclusion = $true
         }
-        $body = @{
-            value = $CustomerTenantID
-        }
-        Write-Verbose "Adding Tenant $CustomerTenantID to the exclusion list."
-        Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params -Body $body -Method POST
     }
+
+    $body = @{
+        value = $CustomerTenantID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params -Body $body -Method POST
 }

--- a/CIPPAPIModule/public/CIPP/Settings/Set-CIPPExcludeTenant.ps1
+++ b/CIPPAPIModule/public/CIPP/Settings/Set-CIPPExcludeTenant.ps1
@@ -48,15 +48,15 @@ function Set-CIPPExcludeTenant {
     $endpoint = '/api/execexcludetenant'
 
     if ($RemoveExclusion) {
-        Write-Verbose "Removing Tenant $CustomerTenantID from the exclusion list."
         $params = @{
             RemoveExclusion = $true
         }
+        Write-Verbose "Removing Tenant $CustomerTenantID from the exclusion list."
     } else {
-		Write-Verbose "Adding Tenant $CustomerTenantID to the exclusion list."    
         $params = @{
             AddExclusion = $true
         }
+        Write-Verbose "Adding Tenant $CustomerTenantID to the exclusion list."    
     }
 
     $body = @{


### PR DESCRIPTION
I'm on CIPP-API v10.4.4 and this command wasn't working. Turns out it needed the tenantId in the body. The response is expecting tenantId in the parameters, so this change causes the tenantId to be missing from the response.

I went this route because the current CIPP frontend isn't including the tenantid in the request, but it wouldn't hurt to have it in both places. I'm betting the backend will get fixed and this issue will resolve itself.