### PR TITLE
Create a function to set the tenant alias in CIPP

### DIFF
--- a/CIPPAPIModule/public/Tenant/Administration/Tenant/Set-CIPPTenantProperties.ps1
+++ b/CIPPAPIModule/public/Tenant/Administration/Tenant/Set-CIPPTenantProperties.ps1
@@ -1,0 +1,49 @@
+<#
+.SYNOPSIS
+    Sets properties for a tenant in the CIPP system.
+
+.DESCRIPTION
+    The Set-CIPPTenantProperty function sets the alias and tenant group for a specific tenant.
+
+.PARAMETER CustomerTenantID
+    The customer tenant ID
+	
+.PARAMETER TenantAlias
+    The tenant alias
+
+.PARAMETER TenantGroups
+    The tenant groups
+
+.EXAMPLE
+    Set-CIPPTenantProperty -CustomerTenantID "12345678-1234-1234-1234-1234567890ab" -TenantAlias "Contoso, LLC"
+    Updates the TenantAlias for the specified tenant and removes existing TenantGroups
+
+.EXAMPLE
+    Set-CIPPTenantProperty -CustomerTenantID "12345678-1234-1234-1234-1234567890ab" -TenantAlias "Contoso, LLC" -TenantGroups 
+    Adds or updates the TenantAlias and TenantGroups for the specified tenant.
+#>
+function Set-CIPPCustomVariable {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TenantAlias,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable][]$TenantGroups = @(),
+
+    )
+
+    Write-Verbose "Setting properties for the tenant $CustomerTenantID"
+
+    $endpoint = '/api/EditTenant'
+    $body = @{
+        customerId    = $CustomerTenantID
+        tenantAlias   = $tenantAlias
+        tenantGroups  = $tenantGroups
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Body $body -Method POST
+}


### PR DESCRIPTION
You need to get the current groups to run this command and keep the existing groups I don't use tenant groups and did not look into how that could be done.

```
# Get tenant names from the https://api.partnercenter.microsoft.com/v1/customers MSPC endpoint. 
# This function is a workaround while until the following feature request is implemented https://github.com/KelvinTegelaar/CIPP/issues/6057
# The live company name is also available from Get-CIPPTenantDetails
$t = Get-M365Tenants
$tht = $t|group tenantid -AsHashTable

# Get CIPP Tenants
$ct = Get-CIPPTenants

# compare the live name with the name in CIPP
$ct2 = $ct|?{$tht.($_.customerid).companyname -ne $_.displayname}|select *,@{n="MSPCDisplayName";e={$tht.($_.customerid).companyname}}
$ct2 = $ct2|?{$_.mspcdisplayname}
$ct2|select customerId,displayname,mspcdisplayname
```

This is what I used prior to making this function:

```
$endpoint = "/api/EditTenant"
$method = "POST"

$ct2|%{
        $body = @{tenantAlias = $_.MSPCDisplayName; tenantGroups = @(); customerId = $_.customerId}
        Invoke-CIPPRestMethod -Endpoint $endpoint -Method $method -Body $Body
}
```

This is what I will use when syncing names manually in the future:

```
$ct2|%{
        Set-CIPPTenantProperty -CustomerTenantID $_.customerId -TenantAlias $_.MSPCDisplayName
}
```