### PR TITLE
Feat: Add UseReportDB parameter for cached data retrieval

### DIFF
--- a/CIPPAPIModule/public/Email/Administration/Get-CIPPCalendarPerms.ps1
+++ b/CIPPAPIModule/public/Email/Administration/Get-CIPPCalendarPerms.ps1
@@ -9,11 +9,18 @@ The Get-CIPPCalendarPerms function retrieves the calendar permissions for a user
 The ID of the customer tenant.
 
 .PARAMETER UserID
-The ID of the user.
+The ID of the user. Optional; omit to retrieve calendar permissions for all mailboxes. Cannot be combined with -UseReportDB (the cached report only covers all mailboxes).
+
+.PARAMETER UseReportDB
+When specified, retrieves calendar permissions from the CIPP report database cache instead of live Exchange Online data. The backend only serves cached data when no UserID is supplied. Use 'AllTenants' with this switch for cached cross-tenant data.
 
 .EXAMPLE
 Get-CIPPCalendarPerms -CustomerTenantID "7ced1621-b8f7-4231-868c-bc6b1a2f1778" -UserID "john.doe@example.com"
 Retrieves the calendar permissions for the user "john.doe@example.com" in the customer tenant with ID "7ced1621-b8f7-4231-868c-bc6b1a2f1778".
+
+.EXAMPLE
+Get-CIPPCalendarPerms -CustomerTenantID "contoso.onmicrosoft.com" -UseReportDB
+Retrieves the cached calendar permissions report for all mailboxes in the "contoso.onmicrosoft.com" tenant from the report database.
 
 #>
 
@@ -22,15 +29,22 @@ function Get-CIPPCalendarPerms {
     Param(
         [Parameter(Mandatory = $true)]
         [string]$CustomerTenantID,
-        [Parameter(Mandatory = $true)]
-        [string]$UserID
+        [Parameter(Mandatory = $false)]
+        [string]$UserID,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
     )
+
+    if ($UserID -and $UseReportDB) {
+        throw 'Parameter combination is not valid. -UseReportDB returns the cached report for all mailboxes and cannot be combined with -UserID.'
+    }
 
     Write-Verbose "Getting user calendar permissions for user: $UserID"
     $Endpoint = '/api/listcalendarpermissions'
     $Params = @{
         tenantFilter = $CustomerTenantID
         userId       = $UserID
+        UseReportDB  = $UseReportDB.IsPresent
     }
     Invoke-CIPPRestMethod -Endpoint $Endpoint -Params $Params
 }

--- a/CIPPAPIModule/public/Email/Administration/Get-CIPPHVEAccounts.ps1
+++ b/CIPPAPIModule/public/Email/Administration/Get-CIPPHVEAccounts.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+Retrieves High Volume Email (HVE) accounts for a specified customer tenant.
+
+.DESCRIPTION
+The Get-CIPPHVEAccounts function retrieves High Volume Email (HVE) accounts for a specified customer tenant by making a REST API call to the "/api/ListHVEAccounts" endpoint. It can query live data or cached report database data when UseReportDB is specified.
+
+.PARAMETER CustomerTenantID
+The customer tenant ID or default domain name for which to retrieve HVE accounts.
+
+.PARAMETER UseReportDB
+When specified, retrieves HVE accounts from the CIPP report database cache instead of live data. Use 'AllTenants' with this switch for cached cross-tenant data.
+
+.EXAMPLE
+Get-CIPPHVEAccounts -CustomerTenantID "contoso.onmicrosoft.com"
+Retrieves live HVE accounts for the "contoso.onmicrosoft.com" tenant.
+
+.EXAMPLE
+Get-CIPPHVEAccounts -CustomerTenantID "contoso.onmicrosoft.com" -UseReportDB
+Retrieves the cached HVE accounts for the "contoso.onmicrosoft.com" tenant from the report database.
+#>
+function Get-CIPPHVEAccounts {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
+    )
+
+    Write-Verbose "Getting HVE accounts for $CustomerTenantID"
+    $endpoint = '/api/ListHVEAccounts'
+    $params = @{
+        tenantFilter = $CustomerTenantID
+        UseReportDB  = $UseReportDB.IsPresent
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params -Method GET
+}

--- a/CIPPAPIModule/public/Email/Administration/Get-CIPPMailboxPermissions.ps1
+++ b/CIPPAPIModule/public/Email/Administration/Get-CIPPMailboxPermissions.ps1
@@ -9,12 +9,20 @@ The Get-CIPPMailboxPermissions function retrieves mailbox permissions for a spec
 The ID of the customer tenant for which mailbox permissions are to be retrieved. This parameter is mandatory.
 
 .PARAMETER UserID
-The ID of the user for which mailbox permissions are to be retrieved. This parameter is mandatory.
+The ID of the user for which mailbox permissions are to be retrieved. Optional; omit to retrieve permissions for all mailboxes. Cannot be combined with -UseReportDB (the cached report only covers all mailboxes).
+
+.PARAMETER UseReportDB
+When specified, retrieves mailbox permissions from the CIPP report database cache instead of live Exchange Online data. The backend only serves cached data when no UserID is supplied. Use 'AllTenants' with this switch for cached cross-tenant data.
 
 .EXAMPLE
 Get-CIPPMailboxPermissions -CustomerTenantID "7ced1621-b8f7-4231-868c-bc6b1a2f1778" -UserID "user1@domain.com"
 
 This example retrieves mailbox permissions for the customer tenant with ID "7ced1621-b8f7-4231-868c-bc6b1a2f1778" and the user with ID "user1@domain.com".
+
+.EXAMPLE
+Get-CIPPMailboxPermissions -CustomerTenantID "contoso.onmicrosoft.com" -UseReportDB
+
+This example retrieves the cached mailbox permissions report for all mailboxes in the "contoso.onmicrosoft.com" tenant from the report database.
 
 #>
 
@@ -23,15 +31,22 @@ function Get-CIPPMailboxPermissions {
     Param(
         [Parameter(Mandatory = $true)]
         [string]$CustomerTenantID,
-        [Parameter(Mandatory = $true)]
-        [string]$UserID
+        [Parameter(Mandatory = $false)]
+        [string]$UserID,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
     )
+
+    if ($UserID -and $UseReportDB) {
+        throw 'Parameter combination is not valid. -UseReportDB returns the cached report for all mailboxes and cannot be combined with -UserID.'
+    }
 
     Write-Verbose "Getting mailbox permissions for $CustomerTenantID"
     $endpoint = '/api/listmailboxpermissions'
     $params = @{
         tenantFilter = $CustomerTenantID
         userid       = $UserID
+        UseReportDB  = $UseReportDB.IsPresent
     }
     Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
 }

--- a/CIPPAPIModule/public/Email/Administration/Get-CIPPMailboxRules.ps1
+++ b/CIPPAPIModule/public/Email/Administration/Get-CIPPMailboxRules.ps1
@@ -8,23 +8,34 @@ The Get-CIPPMailboxRules function retrieves mailbox rules for a specified custom
 .PARAMETER CustomerTenantID
 The customer tenant ID for which to retrieve mailbox rules.
 
+.PARAMETER UseReportDB
+When specified, retrieves mailbox rules from the CIPP report database cache instead of live Exchange Online data. Use 'AllTenants' with this switch for cached cross-tenant data.
+
 .EXAMPLE
 Get-CIPPMailboxRules -CustomerTenantID "contoso.onmicrosoft.com"
 
 This example retrieves mailbox rules for the customer tenant with the ID "contoso.onmicrosoft.com".
+
+.EXAMPLE
+Get-CIPPMailboxRules -CustomerTenantID "contoso.onmicrosoft.com" -UseReportDB
+
+This example retrieves cached mailbox rules for the "contoso.onmicrosoft.com" tenant from the report database.
 
 #>
 function Get-CIPPMailboxRules {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $true)]
-        [string]$CustomerTenantID
+        [string]$CustomerTenantID,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
     )
-    
+
     Write-Verbose "Getting mailbox rules for $CustomerTenantID"
     $endpoint = '/api/listmailboxrules'
     $params = @{
         tenantFilter = $CustomerTenantID
+        UseReportDB  = $UseReportDB.IsPresent
     }
     Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
 }

--- a/CIPPAPIModule/public/Email/Administration/Get-CIPPMailboxes.ps1
+++ b/CIPPAPIModule/public/Email/Administration/Get-CIPPMailboxes.ps1
@@ -11,6 +11,9 @@ Specifies the customer tenant ID for which to retrieve the mailbox list.
 .PARAMETER SoftDeletedMailboxes
 Indicates whether to include soft-deleted mailboxes in the result. By default, this parameter is set to $false.
 
+.PARAMETER UseReportDB
+When specified, retrieves the mailbox list from the CIPP report database cache instead of live Exchange Online data. Use 'AllTenants' with this switch for cached cross-tenant data.
+
 .EXAMPLE
 Get-CIPPMailboxes -CustomerTenantID "contoso.onmicrosoft.com"
 Retrieves the list of mailboxes for the "contoso.onmicrosoft.com" tenant.
@@ -18,6 +21,10 @@ Retrieves the list of mailboxes for the "contoso.onmicrosoft.com" tenant.
 .EXAMPLE
 Get-CIPPMailboxes -CustomerTenantID "contoso.onmicrosoft.com" -SoftDeletedMailboxes
 Retrieves the list of soft-deleted mailboxes for the "contoso.onmicrosoft.com" tenant.
+
+.EXAMPLE
+Get-CIPPMailboxes -CustomerTenantID "contoso.onmicrosoft.com" -UseReportDB
+Retrieves the cached list of mailboxes for the "contoso.onmicrosoft.com" tenant from the report database.
 #>
 
 function Get-CIPPMailboxes {
@@ -26,13 +33,16 @@ function Get-CIPPMailboxes {
         [Parameter(Mandatory = $true)]
         [string]$CustomerTenantID,
         [Parameter(Mandatory = $false)]
-        [switch]$SoftDeletedMailboxes
+        [switch]$SoftDeletedMailboxes,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
     )
 
     Write-Verbose "Getting Mailbox List for $CustomerTenantID"
     $endpoint = '/api/ListMailboxes'
     $params = @{
         tenantFilter = $CustomerTenantID
+        UseReportDB  = $UseReportDB.IsPresent
     }
     if ($SoftDeletedMailboxes) {
         $params.Add('SoftDeletedMailbox', 'true')

--- a/CIPPAPIModule/public/Email/Reports/Get-CIPPMailboxForwarding.ps1
+++ b/CIPPAPIModule/public/Email/Reports/Get-CIPPMailboxForwarding.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+Retrieves mailbox forwarding configuration for a specified customer tenant.
+
+.DESCRIPTION
+The Get-CIPPMailboxForwarding function retrieves mailbox forwarding configuration for a specified customer tenant by making a REST API call to the "/api/ListMailboxForwarding" endpoint. It can query live Exchange Online data or cached report database data when UseReportDB is specified.
+
+.PARAMETER CustomerTenantID
+The customer tenant ID or default domain name for which to retrieve mailbox forwarding configuration.
+
+.PARAMETER UseReportDB
+When specified, retrieves mailbox forwarding configuration from the CIPP report database cache instead of live Exchange Online data. Use 'AllTenants' with this switch for cached cross-tenant data.
+
+.EXAMPLE
+Get-CIPPMailboxForwarding -CustomerTenantID "contoso.onmicrosoft.com"
+Retrieves live mailbox forwarding configuration for the "contoso.onmicrosoft.com" tenant.
+
+.EXAMPLE
+Get-CIPPMailboxForwarding -CustomerTenantID "contoso.onmicrosoft.com" -UseReportDB
+Retrieves the cached mailbox forwarding report for the "contoso.onmicrosoft.com" tenant from the report database.
+#>
+function Get-CIPPMailboxForwarding {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
+    )
+
+    Write-Verbose "Getting mailbox forwarding for $CustomerTenantID"
+    $endpoint = '/api/ListMailboxForwarding'
+    $params = @{
+        tenantFilter = $CustomerTenantID
+        UseReportDB  = $UseReportDB.IsPresent
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params -Method GET
+}

--- a/CIPPAPIModule/public/Endpoint/Applications/Get-CIPPApps.ps1
+++ b/CIPPAPIModule/public/Endpoint/Applications/Get-CIPPApps.ps1
@@ -8,22 +8,32 @@ The Get-CIPPApps function retrieves a list of apps for a specific customer tenan
 .PARAMETER CustomerTenantID
 Specifies the customer tenant ID for which to retrieve the apps.
 
+.PARAMETER UseReportDB
+When specified, retrieves the application list from the CIPP report database cache instead of live Microsoft Graph data. Use 'AllTenants' with this switch for cached cross-tenant data.
+
 .EXAMPLE
 Get-CIPPApps -CustomerTenantID "7ced1621-b8f7-4231-868c-bc6b1a2f1778"
 Retrieves a list of apps for the customer tenant ID "7ced1621-b8f7-4231-868c-bc6b1a2f1778".
+
+.EXAMPLE
+Get-CIPPApps -CustomerTenantID "7ced1621-b8f7-4231-868c-bc6b1a2f1778" -UseReportDB
+Retrieves the cached application list for the customer tenant from the report database.
 
 #>
 function Get-CIPPApps {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $true)]
-        [string]$CustomerTenantID
+        [string]$CustomerTenantID,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
     )
 
     Write-Verbose "Getting Apps for $CustomerTenantID"
     $Endpoint = '/api/listapps'
     $Params = @{
         tenantFilter = $CustomerTenantID
+        UseReportDB  = $UseReportDB.IsPresent
     }
 
     Invoke-CIPPRestMethod -Endpoint $Endpoint -Params $Params

--- a/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPAppProtectionPolicies.ps1
+++ b/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPAppProtectionPolicies.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+Retrieves Intune app protection policies for a specified customer tenant.
+
+.DESCRIPTION
+The Get-CIPPAppProtectionPolicies function retrieves Intune app protection (MAM) policies for a specified customer tenant by making a REST API call to the "/api/ListAppProtectionPolicies" endpoint. It can query live Microsoft Graph data or cached report database data when UseReportDB is specified.
+
+.PARAMETER CustomerTenantID
+The customer tenant ID or default domain name for which to retrieve app protection policies.
+
+.PARAMETER UseReportDB
+When specified, retrieves app protection policies from the CIPP report database cache instead of live Microsoft Graph data. Use 'AllTenants' with this switch for cached cross-tenant data.
+
+.EXAMPLE
+Get-CIPPAppProtectionPolicies -CustomerTenantID "contoso.onmicrosoft.com"
+Retrieves live Intune app protection policies for the "contoso.onmicrosoft.com" tenant.
+
+.EXAMPLE
+Get-CIPPAppProtectionPolicies -CustomerTenantID "contoso.onmicrosoft.com" -UseReportDB
+Retrieves the cached Intune app protection policies for the "contoso.onmicrosoft.com" tenant from the report database.
+#>
+function Get-CIPPAppProtectionPolicies {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
+    )
+
+    Write-Verbose "Getting app protection policies for $CustomerTenantID"
+    $endpoint = '/api/ListAppProtectionPolicies'
+    $params = @{
+        tenantFilter = $CustomerTenantID
+        UseReportDB  = $UseReportDB.IsPresent
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params -Method GET
+}

--- a/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPAssignmentFilters.ps1
+++ b/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPAssignmentFilters.ps1
@@ -21,6 +21,13 @@ Retrieves all assignment filters for the specified tenant.
 Get-CIPPAssignmentFilters -CustomerTenantID "contoso.onmicrosoft.com" -FilterId "12345678-1234-1234-1234-123456789012"
 Retrieves a specific assignment filter by its ID for the specified tenant.
 
+.PARAMETER UseReportDB
+When specified, retrieves the assignment filter list from the CIPP report database cache instead of live Microsoft Graph data. Only applies when no -FilterId is supplied. Use 'AllTenants' with this switch for cached cross-tenant data.
+
+.EXAMPLE
+Get-CIPPAssignmentFilters -CustomerTenantID "contoso.onmicrosoft.com" -UseReportDB
+Retrieves the cached assignment filter list for the specified tenant from the report database.
+
 .NOTES
 This function requires appropriate permissions to access Microsoft Endpoint Manager data through the CIPP API.
 #>
@@ -31,14 +38,17 @@ function Get-CIPPAssignmentFilters {
         [Parameter(Mandatory = $true)]
         [string]$CustomerTenantID,
         [Parameter(Mandatory = $false)]
-        [guid]$FilterId
+        [guid]$FilterId,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
     )
 
     Write-Verbose "Retrieving assignment filters for tenant: $CustomerTenantID"
-    
+
     $endpoint = '/api/ListAssignmentFilters'
     $params = @{
         tenantFilter = $CustomerTenantID
+        UseReportDB  = $UseReportDB.IsPresent
     }
     
     if ($FilterId) {

--- a/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPCompliancePolicies.ps1
+++ b/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPCompliancePolicies.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+Retrieves Intune device compliance policies for a specified customer tenant.
+
+.DESCRIPTION
+The Get-CIPPCompliancePolicies function retrieves Intune device compliance policies for a specified customer tenant by making a REST API call to the "/api/ListCompliancePolicies" endpoint. It can query live Microsoft Graph data or cached report database data when UseReportDB is specified.
+
+.PARAMETER CustomerTenantID
+The customer tenant ID or default domain name for which to retrieve compliance policies.
+
+.PARAMETER UseReportDB
+When specified, retrieves compliance policies from the CIPP report database cache instead of live Microsoft Graph data. Use 'AllTenants' with this switch for cached cross-tenant data.
+
+.EXAMPLE
+Get-CIPPCompliancePolicies -CustomerTenantID "contoso.onmicrosoft.com"
+Retrieves live Intune compliance policies for the "contoso.onmicrosoft.com" tenant.
+
+.EXAMPLE
+Get-CIPPCompliancePolicies -CustomerTenantID "contoso.onmicrosoft.com" -UseReportDB
+Retrieves the cached Intune compliance policies for the "contoso.onmicrosoft.com" tenant from the report database.
+#>
+function Get-CIPPCompliancePolicies {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
+    )
+
+    Write-Verbose "Getting compliance policies for $CustomerTenantID"
+    $endpoint = '/api/ListCompliancePolicies'
+    $params = @{
+        tenantFilter = $CustomerTenantID
+        UseReportDB  = $UseReportDB.IsPresent
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params -Method GET
+}

--- a/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPIntunePolicy.ps1
+++ b/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPIntunePolicy.ps1
@@ -14,6 +14,9 @@ The ID of the policy. This parameter is optional.
 .PARAMETER Urlname
 The URL name. This parameter is optional.
 
+.PARAMETER UseReportDB
+When specified, retrieves the Intune policy list from the CIPP report database cache instead of live Microsoft Graph data. Only applies to the list view (when no -PolicyID is supplied). Use 'AllTenants' with this switch for cached cross-tenant data.
+
 .EXAMPLE
 Get-CIPPIntunePolicy -CustomerTenantID "7ced1621-b8f7-4231-868c-bc6b1a2f1778" -PolicyID "policy123" -Urlname "example"
 This example retrieves the Intune policies for the customer with the tenant ID "7ced1621-b8f7-4231-868c-bc6b1a2f1778", using the policy ID "policy123" and the URL name "example".
@@ -21,6 +24,10 @@ This example retrieves the Intune policies for the customer with the tenant ID "
 .EXAMPLE
 Get-CIPPIntunePolicy -CustomerTenantID "7ced1621-b8f7-4231-868c-bc6b1a2f1778"
 This example retrieves all Intune policies for the customer with the tenant ID "7ced1621-b8f7-4231-868c-bc6b1a2f1778".
+
+.EXAMPLE
+Get-CIPPIntunePolicy -CustomerTenantID "7ced1621-b8f7-4231-868c-bc6b1a2f1778" -UseReportDB
+This example retrieves the cached Intune policy list for the customer tenant from the report database.
 
 #>
 Function Get-CIPPIntunePolicy {
@@ -31,7 +38,9 @@ Function Get-CIPPIntunePolicy {
         [Parameter(Mandatory = $false)]
         [string]$PolicyID,
         [Parameter(Mandatory = $false)]
-        [string]$Urlname
+        [string]$Urlname,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
     )
 
     Write-Verbose "Getting Intune policies for customer: $CustomerTenantID"
@@ -47,6 +56,7 @@ Function Get-CIPPIntunePolicy {
         tenantFilter = $CustomerTenantID
         URLName      = $urlname
         id           = $PolicyID
+        UseReportDB  = $UseReportDB.IsPresent
     }
     
     # Use the Invoke-CIPPRequest function to make the request

--- a/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPIntuneReusableSettings.ps1
+++ b/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPIntuneReusableSettings.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+Retrieves Intune reusable settings for a specified customer tenant.
+
+.DESCRIPTION
+The Get-CIPPIntuneReusableSettings function retrieves Intune reusable policy settings for a specified customer tenant by making a REST API call to the "/api/ListIntuneReusableSettings" endpoint. It can query live Microsoft Graph data or cached report database data when UseReportDB is specified.
+
+.PARAMETER CustomerTenantID
+The customer tenant ID or default domain name for which to retrieve reusable settings.
+
+.PARAMETER UseReportDB
+When specified, retrieves reusable settings from the CIPP report database cache instead of live Microsoft Graph data. Use 'AllTenants' with this switch for cached cross-tenant data.
+
+.EXAMPLE
+Get-CIPPIntuneReusableSettings -CustomerTenantID "contoso.onmicrosoft.com"
+Retrieves live Intune reusable settings for the "contoso.onmicrosoft.com" tenant.
+
+.EXAMPLE
+Get-CIPPIntuneReusableSettings -CustomerTenantID "contoso.onmicrosoft.com" -UseReportDB
+Retrieves the cached Intune reusable settings for the "contoso.onmicrosoft.com" tenant from the report database.
+#>
+function Get-CIPPIntuneReusableSettings {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
+    )
+
+    Write-Verbose "Getting Intune reusable settings for $CustomerTenantID"
+    $endpoint = '/api/ListIntuneReusableSettings'
+    $params = @{
+        tenantFilter = $CustomerTenantID
+        UseReportDB  = $UseReportDB.IsPresent
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params -Method GET
+}

--- a/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPIntuneScript.ps1
+++ b/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPIntuneScript.ps1
@@ -9,9 +9,16 @@ from Microsoft Endpoint Manager for a specified tenant. The function retrieves a
 .PARAMETER CustomerTenantID
 Specifies the ID of the customer tenant. This parameter is mandatory.
 
+.PARAMETER UseReportDB
+When specified, retrieves Intune scripts from the CIPP report database cache instead of live Microsoft Graph data. Use 'AllTenants' with this switch for cached cross-tenant data.
+
 .EXAMPLE
 Get-CIPPIntuneScript -CustomerTenantID "contoso.onmicrosoft.com"
 Retrieves all Intune scripts for the specified tenant, including Windows PowerShell scripts, macOS shell scripts, remediation scripts, and Linux configuration scripts.
+
+.EXAMPLE
+Get-CIPPIntuneScript -CustomerTenantID "contoso.onmicrosoft.com" -UseReportDB
+Retrieves cached Intune scripts for the specified tenant from the report database.
 
 .NOTES
 This function retrieves the following script types:
@@ -27,14 +34,17 @@ function Get-CIPPIntuneScript {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
-        [string]$CustomerTenantID
+        [string]$CustomerTenantID,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
     )
 
     Write-Verbose "Retrieving Intune scripts for tenant: $CustomerTenantID"
-    
+
     $endpoint = '/api/ListIntuneScript'
     $params = @{
         tenantFilter = $CustomerTenantID
+        UseReportDB  = $UseReportDB.IsPresent
     }
 
     Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params

--- a/CIPPAPIModule/public/Identity/Administration/Groups/Get-CIPPGroups.ps1
+++ b/CIPPAPIModule/public/Identity/Administration/Groups/Get-CIPPGroups.ps1
@@ -17,9 +17,16 @@
 .PARAMETER Owners
     Switch parameter. If specified, retrieves the owners of the specified group.
 
+.PARAMETER UseReportDB
+    When specified, retrieves the groups list from the CIPP report database cache instead of live Microsoft Graph data. Only applies to the list view (when no -GroupID, -Members, or -Owners is supplied). Use 'AllTenants' with this switch for cached cross-tenant data.
+
 .EXAMPLE
     Get-CIPPGroups -CustomerTenantID "7ced1621-b8f7-4231-868c-bc6b1a2f1778"
     Retrieves all groups for the specified customer tenant.
+
+.EXAMPLE
+    Get-CIPPGroups -CustomerTenantID "7ced1621-b8f7-4231-868c-bc6b1a2f1778" -UseReportDB
+    Retrieves the cached groups list for the specified customer tenant from the report database.
 
 .EXAMPLE
     Get-CIPPGroups -CustomerTenantID "7ced1621-b8f7-4231-868c-bc6b1a2f1778" -GroupID "abcdefg"
@@ -43,9 +50,11 @@ function Get-CIPPGroups {
         [Parameter(Mandatory = $false)]
         [switch]$Members,
         [Parameter(Mandatory = $false)]
-        [switch]$Owners
+        [switch]$Owners,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
     )
-    
+
     # Validate parameters
     if (-not $GroupID -and ($Members.IsPresent -or $Owners.IsPresent)) {
         throw 'Parameter combination is not valid. Please provide a GroupID when using Members or Owners switches.'
@@ -67,6 +76,7 @@ function Get-CIPPGroups {
         GroupID      = $GroupID
         members      = $Members.IsPresent ? $true : $null
         owners       = $Owners.IsPresent ? $true : $null
+        UseReportDB  = $UseReportDB.IsPresent
     }
 
     Invoke-CIPPRestMethod -Endpoint $Endpoint -Params $Params

--- a/CIPPAPIModule/public/Identity/Reports/Get-CIPPMFAUsers.ps1
+++ b/CIPPAPIModule/public/Identity/Reports/Get-CIPPMFAUsers.ps1
@@ -8,22 +8,32 @@ The Get-CIPPMFAUsers function retrieves the MFA users for a specified customer t
 .PARAMETER CustomerTenantID
 Specifies the customer tenant ID for which to retrieve the MFA users.
 
+.PARAMETER UseReportDB
+When specified, retrieves the MFA user report from the CIPP report database cache instead of live Microsoft Graph data. Use 'AllTenants' with this switch for cached cross-tenant data.
+
 .EXAMPLE
 Get-CIPPMFAUsers -CustomerTenantID "7ced1621-b8f7-4231-868c-bc6b1a2f1778"
 Retrieves the MFA users for the customer tenant ID "7ced1621-b8f7-4231-868c-bc6b1a2f1778".
+
+.EXAMPLE
+Get-CIPPMFAUsers -CustomerTenantID "7ced1621-b8f7-4231-868c-bc6b1a2f1778" -UseReportDB
+Retrieves the cached MFA user report for the customer tenant from the report database.
 
 #>
 function Get-CIPPMFAUsers {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $true)]
-        [string]$CustomerTenantID
+        [string]$CustomerTenantID,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
     )
 
     Write-Verbose "Getting MFA users for $CustomerTenantID"
     $endpoint = '/api/listmfausers'
     $params = @{
         tenantFilter = $CustomerTenantID
+        UseReportDB  = $UseReportDB.IsPresent
     }
     Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
 }

--- a/CIPPAPIModule/public/Teams-Sharepoint/OneDrive/Get-CIPPOneDriveList.ps1
+++ b/CIPPAPIModule/public/Teams-Sharepoint/OneDrive/Get-CIPPOneDriveList.ps1
@@ -29,6 +29,14 @@ PS> Get-CIPPOneDriveList -CustomerTenantID "example.com" -UserUPN "user@example.
 
 Retrieves a list of OneDrive sites for the customer tenant with the ID "example.com" and the specified user's UPN "user@example.com".
 
+.PARAMETER UseReportDB
+When specified, retrieves OneDrive usage from the CIPP report database cache instead of live data. Use 'AllTenants' with this switch for cached cross-tenant data.
+
+.EXAMPLE
+PS> Get-CIPPOneDriveList -CustomerTenantID "example.com" -UseReportDB
+
+Retrieves cached OneDrive usage for the customer tenant with the ID "example.com" from the report database.
+
 #>
 function Get-CIPPOneDriveList {
     [CmdletBinding()]
@@ -38,7 +46,9 @@ function Get-CIPPOneDriveList {
         [Parameter(Mandatory = $false)]
         [switch]$urlonly,
         [Parameter(Mandatory = $false)]
-        [string]$UserUPN
+        [string]$UserUPN,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
     )
 
     Write-Verbose "Getting sites for $CustomerTenantID"
@@ -47,6 +57,7 @@ function Get-CIPPOneDriveList {
         tenantFilter = $CustomerTenantID
         type         = 'OneDriveUsageAccount'
         userupn      = $UserUPN
+        UseReportDB  = $UseReportDB.IsPresent
     }
 
     if ($urlonly) {

--- a/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPSharePointSites.ps1
+++ b/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPSharePointSites.ps1
@@ -25,6 +25,13 @@ Retrieves only the URLs of the SharePoint sites for the customer tenant "contoso
 .EXAMPLE
 Get-CIPPSharePointSites -CustomerTenantID "contoso.onmicrosoft.com" -UserUPN "user@contoso.com"
 Retrieves SharePoint sites for the user "user@contoso.com" in the customer tenant "contoso.onmicrosoft.com".
+
+.PARAMETER UseReportDB
+When specified, retrieves SharePoint site usage from the CIPP report database cache instead of live data. Use 'AllTenants' with this switch for cached cross-tenant data.
+
+.EXAMPLE
+Get-CIPPSharePointSites -CustomerTenantID "contoso.onmicrosoft.com" -UseReportDB
+Retrieves cached SharePoint site usage for the "contoso.onmicrosoft.com" tenant from the report database.
 #>
 
 function Get-CIPPSharePointSites {
@@ -35,7 +42,9 @@ function Get-CIPPSharePointSites {
         [Parameter(Mandatory = $false)]
         [switch]$urlonly,
         [Parameter(Mandatory = $false)]
-        [string]$UserUPN
+        [string]$UserUPN,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
     )
 
     Write-Verbose "Getting sites for $CustomerTenantID"
@@ -44,6 +53,7 @@ function Get-CIPPSharePointSites {
         tenantFilter = $CustomerTenantID
         type         = 'SharePointSiteUsage'
         userupn      = $UserUPN
+        UseReportDB  = $UseReportDB.IsPresent
     }
 
     if ($urlonly) {

--- a/CIPPAPIModule/public/Teams-Sharepoint/Teams/Get-CIPPTeams.ps1
+++ b/CIPPAPIModule/public/Teams-Sharepoint/Teams/Get-CIPPTeams.ps1
@@ -11,6 +11,9 @@ The customer tenant ID for which to retrieve teams sites. This parameter is mand
 .PARAMETER ID
 The ID of the teams site to retrieve. This parameter is optional.
 
+.PARAMETER UseReportDB
+When specified, retrieves the Teams list from the CIPP report database cache instead of live data. Only applies to the list view (when no -ID is supplied). Use 'AllTenants' with this switch for cached cross-tenant data.
+
 .EXAMPLE
 Get-CIPPTeams -CustomerTenantID "contoso.onmicrosoft.com"
 Retrieves all teams sites for the "contoso.onmicrosoft.com" tenant.
@@ -18,6 +21,10 @@ Retrieves all teams sites for the "contoso.onmicrosoft.com" tenant.
 .EXAMPLE
 Get-CIPPTeams -CustomerTenantID "contoso.onmicrosoft.com" -ID "12345"
 Retrieves the teams site with the ID "12345" for the "contoso.onmicrosoft.com" tenant.
+
+.EXAMPLE
+Get-CIPPTeams -CustomerTenantID "contoso.onmicrosoft.com" -UseReportDB
+Retrieves the cached Teams list for the "contoso.onmicrosoft.com" tenant from the report database.
 #>
 
 
@@ -27,7 +34,9 @@ function Get-CIPPTeams {
         [Parameter(Mandatory = $true)]
         [string]$CustomerTenantID,
         [Parameter(Mandatory = $false)]
-        [string]$ID
+        [string]$ID,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
     )
 
     Write-Verbose "Getting teams sites for $CustomerTenantID"
@@ -36,6 +45,7 @@ function Get-CIPPTeams {
         tenantFilter = $CustomerTenantID
         type         = if ($ID) { 'team' } else { 'list' }
         ID           = $id
+        UseReportDB  = $UseReportDB.IsPresent
     }
 
     Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params

--- a/CIPPAPIModule/public/Teams-Sharepoint/Teams/Get-CIPPTeamsActivity.ps1
+++ b/CIPPAPIModule/public/Teams-Sharepoint/Teams/Get-CIPPTeamsActivity.ps1
@@ -8,23 +8,33 @@ The Get-CIPPTeamsActivity function retrieves the activity of Teams users in a sp
 .PARAMETER CustomerTenantID
 The ID of the customer tenant for which to retrieve the Teams activity.
 
+.PARAMETER UseReportDB
+When specified, retrieves the Teams activity report from the CIPP report database cache instead of live data. Use 'AllTenants' with this switch for cached cross-tenant data.
+
 .EXAMPLE
 Get-CIPPTeamsActivity -CustomerTenantID "7ced1621-b8f7-4231-868c-bc6b1a2f1778"
 Retrieves the Teams activity for the customer tenant with the ID "7ced1621-b8f7-4231-868c-bc6b1a2f1778".
+
+.EXAMPLE
+Get-CIPPTeamsActivity -CustomerTenantID "7ced1621-b8f7-4231-868c-bc6b1a2f1778" -UseReportDB
+Retrieves the cached Teams activity report for the customer tenant from the report database.
 
 #>
 function Get-CIPPTeamsActivity {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $true)]
-        [string]$CustomerTenantID
+        [string]$CustomerTenantID,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
     )
-    
+
     Write-Verbose "Getting teams activity $CustomerTenantID"
     $endpoint = '/api/listteamsactivity'
     $params = @{
         tenantFilter = $CustomerTenantID
         type         = 'TeamsUserActivityUser'
+        UseReportDB  = $UseReportDB.IsPresent
     }
 
     Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params

--- a/CIPPAPIModule/public/Teams-Sharepoint/Teams/Get-CIPPTeamsVoice.ps1
+++ b/CIPPAPIModule/public/Teams-Sharepoint/Teams/Get-CIPPTeamsVoice.ps1
@@ -8,22 +8,32 @@ The Get-CIPPTeamsVoice function retrieves teams voice information for a specifie
 .PARAMETER CustomerTenantID
 The customer tenant ID for which to retrieve teams voice information. This parameter is mandatory.
 
+.PARAMETER UseReportDB
+When specified, retrieves Teams voice information from the CIPP report database cache instead of live data. Use 'AllTenants' with this switch for cached cross-tenant data.
+
 .EXAMPLE
 Get-CIPPTeamsVoice -CustomerTenantID "contoso.onmicrosoft.com"
 Retrieves teams voice information for the customer tenant with the ID "contoso.onmicrosoft.com".
+
+.EXAMPLE
+Get-CIPPTeamsVoice -CustomerTenantID "contoso.onmicrosoft.com" -UseReportDB
+Retrieves cached Teams voice information for the "contoso.onmicrosoft.com" tenant from the report database.
 
 #>
 function Get-CIPPTeamsVoice {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $true)]
-        [string]$CustomerTenantID
+        [string]$CustomerTenantID,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
     )
-    
+
     Write-Verbose "Getting teams voice $CustomerTenantID"
     $endpoint = '/api/listteamsvoice'
     $params = @{
         tenantFilter = $CustomerTenantID
+        UseReportDB  = $UseReportDB.IsPresent
     }
 
     Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params

--- a/CIPPAPIModule/public/Tenant/Reports/Get-CIPPOAuthApps.ps1
+++ b/CIPPAPIModule/public/Tenant/Reports/Get-CIPPOAuthApps.ps1
@@ -8,22 +8,32 @@ The Get-CIPPOAuthApps function retrieves OAuth apps for a specific customer tena
 .PARAMETER CustomerTenantID
 The ID of the customer tenant for which to retrieve OAuth apps.
 
+.PARAMETER UseReportDB
+When specified, retrieves OAuth apps from the CIPP report database cache instead of live Microsoft Graph data. Use 'AllTenants' with this switch for cached cross-tenant data.
+
 .EXAMPLE
 Get-CIPPOAuthApps -CustomerTenantID "7ced1621-b8f7-4231-868c-bc6b1a2f1778"
 Retrieves OAuth apps for the customer tenant with the ID "7ced1621-b8f7-4231-868c-bc6b1a2f1778".
+
+.EXAMPLE
+Get-CIPPOAuthApps -CustomerTenantID "7ced1621-b8f7-4231-868c-bc6b1a2f1778" -UseReportDB
+Retrieves cached OAuth apps for the customer tenant from the report database.
 
 #>
 function Get-CIPPOAuthApps {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $true)]
-        [string]$CustomerTenantID
+        [string]$CustomerTenantID,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
     )
-    
+
     Write-Verbose "Getting OAuth apps for $CustomerTenantID"
     $endpoint = '/api/listoauthapps'
     $params = @{
         tenantFilter = $CustomerTenantID
+        UseReportDB  = $UseReportDB.IsPresent
     }
     Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
 }


### PR DESCRIPTION
Introduce the UseReportDB parameter across multiple functions to enable retrieval of cached data from the CIPP report database, enhancing performance and efficiency. This update includes functions for HVE accounts, mailbox forwarding, app protection, compliance policies, and reusable settings.