### PR TITLE
fix: stop wrapping single hashtable Body in array

### DIFF
--- a/CIPPAPIModule/public/CIPP/Core/Get-CIPPAlertResults.ps1
+++ b/CIPPAPIModule/public/CIPP/Core/Get-CIPPAlertResults.ps1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+    ListAlertResults.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListAlertResults.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPAlertResults -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPAlertResults {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListAlertResults from the CIPP API'
+
+    $endpoint = '/api/ListAlertResults'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+    }
+
+    $body = @{}
+    $body['tenantFilter'] = $CustomerTenantID
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/CIPP/Core/Get-CIPPAvailableTests.ps1
+++ b/CIPPAPIModule/public/CIPP/Core/Get-CIPPAvailableTests.ps1
@@ -1,0 +1,36 @@
+<#
+.SYNOPSIS
+    ListAvailableTests.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListAvailableTests.
+
+.PARAMETER Name
+    The Name value sent to the CIPP API.
+
+.PARAMETER Description
+    The Description value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPAvailableTests -Name '<Name>' -Description '<Description>'
+#>
+function Get-CIPPAvailableTests {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Description
+
+    )
+
+    Write-Verbose 'Retrieving ListAvailableTests from the CIPP API'
+
+    $endpoint = '/api/ListAvailableTests'
+    $body = @{}
+    if ($PSBoundParameters.ContainsKey('Name')) { $body['name'] = $Name }
+    if ($PSBoundParameters.ContainsKey('Description')) { $body['description'] = $Description }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint
+}

--- a/CIPPAPIModule/public/CIPP/Core/Get-CIPPDBCache.ps1
+++ b/CIPPAPIModule/public/CIPP/Core/Get-CIPPDBCache.ps1
@@ -1,0 +1,37 @@
+<#
+.SYNOPSIS
+    Retrieves cached tenant data from the CIPP reporting database (CippReportingDB).
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListDBCache.
+
+.PARAMETER Type
+    The Type value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPDBCache -Type '<Type>' -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPDBCache {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$Type,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListDBCache from the CIPP API'
+
+    $endpoint = '/api/ListDBCache'
+    $params = @{
+        type                       = $Type
+        tenantFilter               = $CustomerTenantID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/CIPP/Core/Get-CIPPDiagnosticsPresets.ps1
+++ b/CIPPAPIModule/public/CIPP/Core/Get-CIPPDiagnosticsPresets.ps1
@@ -1,0 +1,19 @@
+<#
+.SYNOPSIS
+    Lists saved diagnostics presets used for troubleshooting CIPP configuration.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListDiagnosticsPresets.
+
+.EXAMPLE
+    Get-CIPPDiagnosticsPresets
+#>
+function Get-CIPPDiagnosticsPresets {
+    [CmdletBinding()]
+    param ()
+
+    Write-Verbose 'Retrieving ListDiagnosticsPresets from the CIPP API'
+
+    $endpoint = '/api/ListDiagnosticsPresets'
+    Invoke-CIPPRestMethod -Endpoint $endpoint
+}

--- a/CIPPAPIModule/public/CIPP/Core/Get-CIPPFeatureFlags.ps1
+++ b/CIPPAPIModule/public/CIPP/Core/Get-CIPPFeatureFlags.ps1
@@ -1,0 +1,19 @@
+<#
+.SYNOPSIS
+    Lists CIPP feature flags and their enabled/disabled state, including environment-driven overrides.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListFeatureFlags.
+
+.EXAMPLE
+    Get-CIPPFeatureFlags
+#>
+function Get-CIPPFeatureFlags {
+    [CmdletBinding()]
+    param ()
+
+    Write-Verbose 'Retrieving ListFeatureFlags from the CIPP API'
+
+    $endpoint = '/api/ListFeatureFlags'
+    Invoke-CIPPRestMethod -Endpoint $endpoint
+}

--- a/CIPPAPIModule/public/CIPP/Core/Get-CIPPSnoozedAlerts.ps1
+++ b/CIPPAPIModule/public/CIPP/Core/Get-CIPPSnoozedAlerts.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    Lists alerts that have been snoozed (temporarily suppressed), filterable by cmdlet name.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListSnoozedAlerts.
+
+.PARAMETER CmdletName
+    The CmdletName value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPSnoozedAlerts -CmdletName '<CmdletName>'
+#>
+function Get-CIPPSnoozedAlerts {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$CmdletName
+
+    )
+
+    Write-Verbose 'Retrieving ListSnoozedAlerts from the CIPP API'
+
+    $endpoint = '/api/ListSnoozedAlerts'
+    $params = @{
+        CmdletName                 = $CmdletName
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/CIPP/Settings/Get-CIPPCIPPUsers.ps1
+++ b/CIPPAPIModule/public/CIPP/Settings/Get-CIPPCIPPUsers.ps1
@@ -1,0 +1,36 @@
+<#
+.SYNOPSIS
+    Lists CIPP platform users and their role assignments from the allowedUsers table.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListCIPPUsers.
+
+.PARAMETER Roles
+    The Roles value sent to the CIPP API.
+
+.PARAMETER UPN
+    The UPN value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPCIPPUsers -Roles '<Roles>' -UPN '<UPN>'
+#>
+function Get-CIPPCIPPUsers {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$Roles,
+
+        [Parameter(Mandatory = $false)]
+        [string]$UPN
+
+    )
+
+    Write-Verbose 'Retrieving ListCIPPUsers from the CIPP API'
+
+    $endpoint = '/api/ListCIPPUsers'
+    $body = @{}
+    if ($PSBoundParameters.ContainsKey('Roles')) { $body['Roles'] = $Roles }
+    if ($PSBoundParameters.ContainsKey('UPN')) { $body['UPN'] = $UPN }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint
+}

--- a/CIPPAPIModule/public/CIPP/Settings/Get-CIPPContainerLogs.ps1
+++ b/CIPPAPIModule/public/CIPP/Settings/Get-CIPPContainerLogs.ps1
@@ -1,0 +1,103 @@
+<#
+.SYNOPSIS
+    Retrieves container logs for the CIPP backend process.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListContainerLogs.
+
+.PARAMETER File
+    The File value sent to the CIPP API.
+
+.PARAMETER Action
+    The Action value sent to the CIPP API.
+
+.PARAMETER Tail
+    The Tail value sent to the CIPP API.
+
+.PARAMETER From
+    The From value sent to the CIPP API.
+
+.PARAMETER Query
+    The Query value sent to the CIPP API.
+
+.PARAMETER Regex
+    The Regex value sent to the CIPP API.
+
+.PARAMETER Search
+    The Search value sent to the CIPP API.
+
+.PARAMETER Level
+    The Level value sent to the CIPP API.
+
+.PARAMETER Exclude
+    The Exclude value sent to the CIPP API.
+
+.PARAMETER SortDesc
+    The SortDesc value sent to the CIPP API.
+
+.PARAMETER To
+    The To value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPContainerLogs -File '<File>' -Action '<Action>' -Tail '<Tail>' -From '<From>' -Query '<Query>' -Regex '<Regex>' -Search '<Search>' -Level '<Level>' -Exclude '<Exclude>' -SortDesc '<SortDesc>' -To '<To>'
+#>
+function Get-CIPPContainerLogs {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$File,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Action,
+
+        [Parameter(Mandatory = $false)]
+        [int]$Tail,
+
+        [Parameter(Mandatory = $false)]
+        [string]$From,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Query,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Regex,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Search,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Level,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Exclude,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$SortDesc,
+
+        [Parameter(Mandatory = $false)]
+        [string]$To
+
+    )
+
+    Write-Verbose 'Retrieving ListContainerLogs from the CIPP API'
+
+    $endpoint = '/api/ListContainerLogs'
+    $params = @{
+        File                       = $File
+        Action                     = $Action
+        Tail                       = $Tail
+        From                       = $From
+        Query                      = $Query
+        Regex                      = $Regex
+        Search                     = $Search
+        Level                      = $Level
+        Exclude                    = $Exclude
+        SortDesc                   = $SortDesc.IsPresent
+        To                         = $To
+    }
+
+    $body = @{}
+    if ($PSBoundParameters.ContainsKey('Query')) { $body['Query'] = $Query }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/CIPP/Settings/Get-CIPPCustomVariableCatalog.ps1
+++ b/CIPPAPIModule/public/CIPP/Settings/Get-CIPPCustomVariableCatalog.ps1
@@ -1,0 +1,44 @@
+<#
+.SYNOPSIS
+    Lists custom variables configured in CIPP for use in templates and automation.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListCustomVariables.
+
+.PARAMETER IncludeSystem
+    The IncludeSystem value sent to the CIPP API.
+
+.PARAMETER ExcludeGlobalReserved
+    The ExcludeGlobalReserved value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPCustomVariableCatalog -IncludeSystem '<IncludeSystem>' -ExcludeGlobalReserved '<ExcludeGlobalReserved>' -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPCustomVariableCatalog {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeSystem,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$ExcludeGlobalReserved,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListCustomVariables from the CIPP API'
+
+    $endpoint = '/api/ListCustomVariables'
+    $params = @{
+        includeSystem              = $IncludeSystem.IsPresent
+        excludeGlobalReserved      = $ExcludeGlobalReserved.IsPresent
+        tenantFilter               = $CustomerTenantID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/CIPP/Settings/Get-CIPPExcludedLicenses.ps1
+++ b/CIPPAPIModule/public/CIPP/Settings/Get-CIPPExcludedLicenses.ps1
@@ -1,31 +1,19 @@
 <#
 .SYNOPSIS
-Retrieves the list of excluded licenses from CIPP.
+    Lists license SKUs that have been excluded from CIPP license counts and reporting.
 
 .DESCRIPTION
-The Get-CIPPExcludedLicenses function is used to retrieve the list of excluded licenses from CIPP. It sends a request to the API endpoint "/api/execexcludelicenses" with the parameter "List" set to "true" to get the excluded license list.
-
-.PARAMETER None
-This function does not accept any parameters.
+    Retrieves data from the CIPP API endpoint /api/ListExcludedLicenses.
 
 .EXAMPLE
-Get-CIPPExcludedLicenses
-# Retrieves the list of excluded licenses from the CIPP API.
-
-.NOTES
-This function requires the Invoke-CIPPRestMethod function to be available in the current session.
+    Get-CIPPExcludedLicenses
 #>
-
 function Get-CIPPExcludedLicenses {
     [CmdletBinding()]
-    Param()
+    param ()
 
-    Write-Verbose 'Getting Excluded License List'
+    Write-Verbose 'Retrieving ListExcludedLicenses from the CIPP API'
 
-    $endpoint = '/api/ExecExcludeLicenses'
-    $params = @{
-        List = 'true'
-    }
-
-    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+    $endpoint = '/api/ListExcludedLicenses'
+    Invoke-CIPPRestMethod -Endpoint $endpoint
 }

--- a/CIPPAPIModule/public/CIPP/Settings/Get-CIPPWorkerHealth.ps1
+++ b/CIPPAPIModule/public/CIPP/Settings/Get-CIPPWorkerHealth.ps1
@@ -1,0 +1,91 @@
+<#
+.SYNOPSIS
+    Retrieves health status and diagnostics for CIPP background worker processes.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListWorkerHealth.
+
+.PARAMETER Priority
+    The Priority value sent to the CIPP API.
+
+.PARAMETER Action
+    The Action value sent to the CIPP API.
+
+.PARAMETER Minutes
+    The Minutes value sent to the CIPP API.
+
+.PARAMETER PoolType
+    The PoolType value sent to the CIPP API.
+
+.PARAMETER Limit
+    The Limit value sent to the CIPP API.
+
+.PARAMETER JobID
+    The JobID value sent to the CIPP API.
+
+.PARAMETER MaxPoints
+    The MaxPoints value sent to the CIPP API.
+
+.PARAMETER RunName
+    The RunName value sent to the CIPP API.
+
+.PARAMETER Status
+    The Status value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPWorkerHealth -Priority '<Priority>' -Action '<Action>' -Minutes '<Minutes>' -PoolType '<PoolType>' -Limit '<Limit>' -JobID '<JobID>' -MaxPoints '<MaxPoints>' -RunName '<RunName>' -Status '<Status>'
+#>
+function Get-CIPPWorkerHealth {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$Priority,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Action,
+
+        [Parameter(Mandatory = $false)]
+        [int]$Minutes,
+
+        [Parameter(Mandatory = $false)]
+        [string]$PoolType,
+
+        [Parameter(Mandatory = $false)]
+        [int]$Limit,
+
+        [Parameter(Mandatory = $false)]
+        [string]$JobID,
+
+        [Parameter(Mandatory = $false)]
+        [int]$MaxPoints,
+
+        [Parameter(Mandatory = $false)]
+        [string]$RunName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Status
+
+    )
+
+    Write-Verbose 'Retrieving ListWorkerHealth from the CIPP API'
+
+    $endpoint = '/api/ListWorkerHealth'
+    $params = @{
+        Priority                   = $Priority
+        Action                     = $Action
+        Minutes                    = $Minutes
+        PoolType                   = $PoolType
+        Limit                      = $Limit
+        JobId                      = $JobID
+        MaxPoints                  = $MaxPoints
+        RunName                    = $RunName
+        Status                     = $Status
+    }
+
+    $body = @{}
+    if ($PSBoundParameters.ContainsKey('Priority')) { $body['Priority'] = $Priority }
+    if ($PSBoundParameters.ContainsKey('JobID')) { $body['JobId'] = $JobID }
+    if ($PSBoundParameters.ContainsKey('RunName')) { $body['RunName'] = $RunName }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params -Body $body -Method POST
+}

--- a/CIPPAPIModule/public/CIPP/Tools/Custom-Scripts/Get-CIPPCustomScripts.ps1
+++ b/CIPPAPIModule/public/CIPP/Tools/Custom-Scripts/Get-CIPPCustomScripts.ps1
@@ -1,0 +1,41 @@
+<#
+.SYNOPSIS
+    Lists custom PowerShell scripts stored in CIPP, with optional filtering by script GUID and version history.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListCustomScripts.
+
+.PARAMETER IncludeAllVersions
+    The IncludeAllVersions value sent to the CIPP API.
+
+.PARAMETER ScriptGUID
+    The ScriptGUID value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPCustomScripts -IncludeAllVersions '<IncludeAllVersions>' -ScriptGUID '<ScriptGUID>'
+#>
+function Get-CIPPCustomScripts {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeAllVersions,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ScriptGUID
+
+    )
+
+    Write-Verbose 'Retrieving ListCustomScripts from the CIPP API'
+
+    $endpoint = '/api/ListCustomScripts'
+    $params = @{
+        IncludeAllVersions         = $IncludeAllVersions.IsPresent
+        ScriptGuid                 = $ScriptGUID
+    }
+
+    $body = @{}
+    if ($PSBoundParameters.ContainsKey('IncludeAllVersions')) { $body['IncludeAllVersions'] = $IncludeAllVersions.IsPresent }
+    if ($PSBoundParameters.ContainsKey('ScriptGUID')) { $body['ScriptGuid'] = $ScriptGUID }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params -Body $body -Method POST
+}

--- a/CIPPAPIModule/public/CIPP/Tools/Get-CIPPGeneratedReports.ps1
+++ b/CIPPAPIModule/public/CIPP/Tools/Get-CIPPGeneratedReports.ps1
@@ -1,0 +1,37 @@
+<#
+.SYNOPSIS
+    Lists generated reports from the CIPP Report Builder, filterable by tenant or report GUID.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListGeneratedReports.
+
+.PARAMETER ReportGUID
+    The ReportGUID value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPGeneratedReports -ReportGUID '<ReportGUID>' -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPGeneratedReports {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$ReportGUID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListGeneratedReports from the CIPP API'
+
+    $endpoint = '/api/ListGeneratedReports'
+    $params = @{
+        ReportGUID                 = $ReportGUID
+        tenantFilter               = $CustomerTenantID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/CIPP/Tools/Get-CIPPReportBuilderTemplates.ps1
+++ b/CIPPAPIModule/public/CIPP/Tools/Get-CIPPReportBuilderTemplates.ps1
@@ -1,0 +1,19 @@
+<#
+.SYNOPSIS
+    Lists saved Report Builder templates that define custom report configurations with data blocks and formatting.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListReportBuilderTemplates.
+
+.EXAMPLE
+    Get-CIPPReportBuilderTemplates
+#>
+function Get-CIPPReportBuilderTemplates {
+    [CmdletBinding()]
+    param ()
+
+    Write-Verbose 'Retrieving ListReportBuilderTemplates from the CIPP API'
+
+    $endpoint = '/api/ListReportBuilderTemplates'
+    Invoke-CIPPRestMethod -Endpoint $endpoint
+}

--- a/CIPPAPIModule/public/Email/Reports/Get-CIPPActiveSyncDevices.ps1
+++ b/CIPPAPIModule/public/Email/Reports/Get-CIPPActiveSyncDevices.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    Lists all ActiveSync mobile devices registered across Exchange Online mailboxes in a tenant.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListActiveSyncDevices.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPActiveSyncDevices -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPActiveSyncDevices {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListActiveSyncDevices from the CIPP API'
+
+    $endpoint = '/api/ListActiveSyncDevices'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Email/Spamfilter/Get-CIPPTenantAllowBlockListTemplates.ps1
+++ b/CIPPAPIModule/public/Email/Spamfilter/Get-CIPPTenantAllowBlockListTemplates.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    Lists saved Tenant Allow/Block List templates for Exchange Online Protection.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListTenantAllowBlockListTemplates.
+
+.PARAMETER ID
+    The ID value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPTenantAllowBlockListTemplates -ID '<ID>'
+#>
+function Get-CIPPTenantAllowBlockListTemplates {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$ID
+
+    )
+
+    Write-Verbose 'Retrieving ListTenantAllowBlockListTemplates from the CIPP API'
+
+    $endpoint = '/api/ListTenantAllowBlockListTemplates'
+    $params = @{
+        ID                         = $ID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Endpoint/Applications/Get-CIPPAppTemplates.ps1
+++ b/CIPPAPIModule/public/Endpoint/Applications/Get-CIPPAppTemplates.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    ListAppTemplates.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListAppTemplates.
+
+.PARAMETER ID
+    The ID value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPAppTemplates -ID '<ID>'
+#>
+function Get-CIPPAppTemplates {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$ID
+
+    )
+
+    Write-Verbose 'Retrieving ListAppTemplates from the CIPP API'
+
+    $endpoint = '/api/ListAppTemplates'
+    $params = @{
+        ID                         = $ID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Endpoint/Autopilot/Get-CIPPAPDevices.ps1
+++ b/CIPPAPIModule/public/Endpoint/Autopilot/Get-CIPPAPDevices.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    Lists Windows Autopilot device identities registered in a tenant.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListAPDevices.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPAPDevices -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPAPDevices {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListAPDevices from the CIPP API'
+
+    $endpoint = '/api/ListAPDevices'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Endpoint/Autopilot/Get-CIPPAutoPilotConfig.ps1
+++ b/CIPPAPIModule/public/Endpoint/Autopilot/Get-CIPPAutoPilotConfig.ps1
@@ -3,7 +3,7 @@
     Retrieves AutoPilot configuration information for a specified customer tenant ID and type.
 
 .DESCRIPTION
-    The Get-CIPPAutoPilotConfig function retrieves AutoPilot configuration information for a specified customer tenant ID and type. 
+    The Get-CIPPAutoPilotConfig function retrieves AutoPilot configuration information for a specified customer tenant ID and type.
     It makes a REST API call to the generic Graph request endpoint to retrieve the configuration data.
 
 .PARAMETER CustomerTenantID
@@ -30,13 +30,13 @@ function Get-CIPPAutoPilotConfig {
         [ValidateSet('ESP', 'ApProfile')]
         [string]$Type
     )
-    
+
     if ($Type -eq 'ESP') {
         Write-Verbose "Getting AutoPilot Status Page for $CustomerTenantID"
     } elseif ($Type -eq 'ApProfile') {
         Write-Verbose "Getting AutoPilot Profile for customer: $CustomerTenantID"
     }
-    
+
     $Endpoint = '/api/ListGraphRequest'
     $Params = @{
         tenantFilter = $CustomerTenantID
@@ -50,6 +50,6 @@ function Get-CIPPAutoPilotConfig {
         $Params['endpoint'] = 'deviceManagement/windowsAutopilotDeploymentProfiles'
         $Params['$expand'] = 'assignments'
     }
-        
+
     (Invoke-CIPPRestMethod -Endpoint $Endpoint -Params $Params).Results
 }

--- a/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPAndroidEnrollmentProfiles.ps1
+++ b/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPAndroidEnrollmentProfiles.ps1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+    Lists Android Enterprise enrollment profiles and hydrates token fields when Graph omits them from the list response.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListAndroidEnrollmentProfiles.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPAndroidEnrollmentProfiles -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPAndroidEnrollmentProfiles {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListAndroidEnrollmentProfiles from the CIPP API'
+
+    $endpoint = '/api/ListAndroidEnrollmentProfiles'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+    }
+
+    $body = @{}
+    $body['tenantFilter'] = $CustomerTenantID
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params -Body $body -Method POST
+}

--- a/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPAppleEnrollmentProfiles.ps1
+++ b/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPAppleEnrollmentProfiles.ps1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+    Lists Apple Automated Device Enrollment tokens and enrollment profiles.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListAppleEnrollmentProfiles.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPAppleEnrollmentProfiles -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPAppleEnrollmentProfiles {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListAppleEnrollmentProfiles from the CIPP API'
+
+    $endpoint = '/api/ListAppleEnrollmentProfiles'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+    }
+
+    $body = @{}
+    $body['tenantFilter'] = $CustomerTenantID
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params -Body $body -Method POST
+}

--- a/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPCVEManagement.ps1
+++ b/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPCVEManagement.ps1
@@ -1,0 +1,37 @@
+<#
+.SYNOPSIS
+    ListCVEManagement.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListCVEManagement.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER UseReportDB
+    The UseReportDB value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPCVEManagement -CustomerTenantID '<CustomerTenantID>' -UseReportDB '<UseReportDB>'
+#>
+function Get-CIPPCVEManagement {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$UseReportDB
+
+    )
+
+    Write-Verbose 'Retrieving ListCVEManagement from the CIPP API'
+
+    $endpoint = '/api/ListCVEManagement'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+        UseReportDB                = $UseReportDB.IsPresent
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPIntuneReusableSettingTemplates.ps1
+++ b/CIPPAPIModule/public/Endpoint/MEM/Get-CIPPIntuneReusableSettingTemplates.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    ListIntuneReusableSettingTemplates.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListIntuneReusableSettingTemplates.
+
+.PARAMETER ID
+    The ID value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPIntuneReusableSettingTemplates -ID '<ID>'
+#>
+function Get-CIPPIntuneReusableSettingTemplates {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$ID
+
+    )
+
+    Write-Verbose 'Retrieving ListIntuneReusableSettingTemplates from the CIPP API'
+
+    $endpoint = '/api/ListIntuneReusableSettingTemplates'
+    $params = @{
+        ID                         = $ID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Endpoint/MEM/New-CIPPIntunePolicyClone.ps1
+++ b/CIPPAPIModule/public/Endpoint/MEM/New-CIPPIntunePolicyClone.ps1
@@ -1,0 +1,67 @@
+<#
+.SYNOPSIS
+    Clones an existing Intune policy under a new display name.
+
+.DESCRIPTION
+    The New-CIPPIntunePolicyClone function clones an existing Intune policy in a customer tenant via the CIPP API /api/AddIntunePolicyClone endpoint. The new display name must differ from the source policy's name, otherwise the source policy would be overwritten instead of cloned.
+
+.PARAMETER CustomerTenantID
+    The unique identifier of the customer tenant (domain or GUID).
+
+.PARAMETER ID
+    The unique identifier of the policy to clone.
+
+.PARAMETER NewDisplayName
+    The display name for the cloned policy. Must be different from the source policy's display name.
+
+.PARAMETER URLName
+    The Graph URL name identifying the policy type. Only the listed policy types are supported for cloning. Can be omitted when ODataType is provided.
+
+.PARAMETER ODataType
+    The OData type of the policy (e.g. '#microsoft.graph.androidManagedAppProtection'). Used to derive the policy type when URLName is omitted, and to pick the type-specific Graph endpoint for App Protection policies.
+
+.PARAMETER NewDescription
+    The description for the cloned policy. Defaults to the source policy's description when omitted.
+
+.EXAMPLE
+    New-CIPPIntunePolicyClone -CustomerTenantID 'contoso.onmicrosoft.com' -ID '12345678-1234-1234-1234-1234567890ab' -URLName 'deviceConfigurations' -NewDisplayName 'Baseline config (copy)'
+
+    This example clones the specified device configuration policy under the new display name.
+#>
+function New-CIPPIntunePolicyClone {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$NewDisplayName,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('deviceCompliancePolicies', 'managedAppPolicies', 'mobileAppConfigurations', 'configurationPolicies', 'windowsDriverUpdateProfiles', 'deviceConfigurations', 'groupPolicyConfigurations', 'windowsFeatureUpdateProfiles', 'windowsQualityUpdatePolicies', 'windowsQualityUpdateProfiles')]
+        [string]$URLName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ODataType,
+
+        [Parameter(Mandatory = $false)]
+        [string]$NewDescription
+    )
+
+    Write-Verbose "Cloning Intune policy $ID to '$NewDisplayName' for customer: $CustomerTenantID"
+    $Endpoint = '/api/AddIntunePolicyClone'
+
+    $body = @{
+        tenantFilter   = $CustomerTenantID
+        ID             = $ID
+        URLName        = $URLName
+        ODataType      = $ODataType
+        newDisplayName = $NewDisplayName
+        newDescription = $NewDescription
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $Endpoint -Body $body -Method 'POST'
+}

--- a/CIPPAPIModule/public/Endpoint/MEM/Set-CIPPIntunePolicyAssignment.ps1
+++ b/CIPPAPIModule/public/Endpoint/MEM/Set-CIPPIntunePolicyAssignment.ps1
@@ -1,0 +1,131 @@
+<#
+.SYNOPSIS
+    Assigns an Intune policy to groups in a customer tenant.
+
+.DESCRIPTION
+    The Set-CIPPIntunePolicyAssignment function assigns an Intune policy via the CIPP API /api/ExecAssignPolicy endpoint. Policies can be assigned to broad targets (all users/devices), specific groups by ID or name, and groups can be excluded. Assignment mode controls whether the new assignment replaces or appends to existing assignments.
+
+.PARAMETER CustomerTenantID
+    The unique identifier of the customer tenant (domain or GUID).
+
+.PARAMETER ID
+    The unique identifier of the policy to assign.
+
+.PARAMETER Type
+    The policy type (e.g. 'deviceConfigurations', 'configurationPolicies', 'deviceCompliancePolicies').
+
+.PARAMETER AssignTo
+    The assignment target: 'allLicensedUsers', 'AllDevices' or 'AllDevicesAndUsers', or one or more group display names (comma-separated).
+
+.PARAMETER PlatformType
+    The Graph API root segment for the policy type: 'deviceManagement' (default server-side) or 'deviceAppManagement' (app protection/configuration policies).
+
+.PARAMETER GroupIds
+    Group object IDs to include in the assignment.
+
+.PARAMETER GroupNames
+    Group display names to include in the assignment.
+
+.PARAMETER ExcludeGroup
+    A single group display name to exclude from the assignment.
+
+.PARAMETER ExcludeGroupIds
+    Group object IDs to exclude from the assignment.
+
+.PARAMETER ExcludeGroupNames
+    Group display names to exclude from the assignment.
+
+.PARAMETER AssignmentMode
+    Whether the assignment replaces existing assignments or appends to them. Valid values are 'replace' and 'append'. Defaults to 'replace' server-side.
+
+.PARAMETER AssignmentDirection
+    Scopes a replace to one direction ('include' or 'exclude'), preserving assignments in the other direction. Sending 'exclude' with replace mode and no exclude groups clears all exclusions.
+
+.PARAMETER AssignmentFilterName
+    The name of an assignment filter to apply.
+
+.PARAMETER AssignmentFilterType
+    The assignment filter type: 'include' or 'exclude'. Defaults to 'include' server-side.
+
+.EXAMPLE
+    Set-CIPPIntunePolicyAssignment -CustomerTenantID 'contoso.onmicrosoft.com' -ID '12345678-1234-1234-1234-1234567890ab' -Type 'deviceConfigurations' -AssignTo 'allLicensedUsers'
+
+    This example assigns the specified device configuration policy to all licensed users.
+
+.EXAMPLE
+    Set-CIPPIntunePolicyAssignment -CustomerTenantID 'contoso.onmicrosoft.com' -ID '12345678-1234-1234-1234-1234567890ab' -Type 'configurationPolicies' -GroupNames 'Sales Users' -AssignmentMode 'append'
+
+    This example appends an assignment for the 'Sales Users' group without touching existing assignments.
+#>
+function Set-CIPPIntunePolicyAssignment {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Type,
+
+        [Parameter(Mandatory = $false)]
+        [string]$AssignTo,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('deviceManagement', 'deviceAppManagement')]
+        [string]$PlatformType,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$GroupIds,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$GroupNames,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ExcludeGroup,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$ExcludeGroupIds,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$ExcludeGroupNames,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('replace', 'append')]
+        [string]$AssignmentMode,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('include', 'exclude')]
+        [string]$AssignmentDirection,
+
+        [Parameter(Mandatory = $false)]
+        [string]$AssignmentFilterName,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('include', 'exclude')]
+        [string]$AssignmentFilterType
+    )
+
+    Write-Verbose "Assigning Intune policy $ID for customer: $CustomerTenantID"
+    $Endpoint = '/api/ExecAssignPolicy'
+
+    $body = @{
+        tenantFilter         = $CustomerTenantID
+        ID                   = $ID
+        Type                 = $Type
+        AssignTo             = $AssignTo
+        platformType         = $PlatformType
+        excludeGroup         = $ExcludeGroup
+        GroupIds             = $GroupIds
+        GroupNames           = $GroupNames
+        ExcludeGroupIds      = $ExcludeGroupIds
+        ExcludeGroupNames    = $ExcludeGroupNames
+        assignmentMode       = $AssignmentMode
+        assignmentDirection  = $AssignmentDirection
+        AssignmentFilterName = $AssignmentFilterName
+        AssignmentFilterType = $AssignmentFilterType
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $Endpoint -Body $body -Method 'POST'
+}

--- a/CIPPAPIModule/public/Endpoint/MEM/Set-CIPPIntunePolicyDetails.ps1
+++ b/CIPPAPIModule/public/Endpoint/MEM/Set-CIPPIntunePolicyDetails.ps1
@@ -1,0 +1,81 @@
+<#
+.SYNOPSIS
+    Updates an Intune policy's name and description.
+
+.DESCRIPTION
+    Updates the name and/or description of an Intune policy in a customer tenant via the CIPP API /api/EditIntunePolicy endpoint. Supply Description as an empty string to clear the existing description.
+
+.PARAMETER CustomerTenantID
+    The tenant to operate on (domain or GUID).
+
+.PARAMETER ID
+    The unique identifier of the Intune policy.
+
+.PARAMETER PolicyType
+    The Graph collection name for the Intune policy.
+
+.PARAMETER NewDisplayName
+    The new display name for the policy.
+
+.PARAMETER Description
+    The new description for the policy. Supply an empty string to clear the existing description.
+
+.PARAMETER PlatformType
+    The Graph platform segment for the policy. Defaults to deviceManagement server-side.
+
+.EXAMPLE
+    Set-CIPPIntunePolicyDetails -CustomerTenantID 'contoso.onmicrosoft.com' -ID '12345678-1234-1234-1234-1234567890ab' -PolicyType 'deviceConfigurations' -NewDisplayName 'Updated baseline' -Description 'Updated configuration baseline'
+
+    Updates the name and description of the specified Intune policy.
+#>
+function Set-CIPPIntunePolicyDetails {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ID,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('deviceConfigurations', 'windowsDriverUpdateProfiles', 'windowsFeatureUpdateProfiles', 'windowsQualityUpdatePolicies', 'windowsQualityUpdateProfiles', 'groupPolicyConfigurations', 'mobileAppConfigurations', 'configurationPolicies', 'deviceCompliancePolicies', 'intents', 'androidManagedAppProtection', 'iosManagedAppProtection', 'windowsManagedAppProtection', 'mdmWindowsInformationProtectionPolicy', 'windowsInformationProtectionPolicy', 'targetedManagedAppConfiguration')]
+        [string]$PolicyType,
+
+        [Parameter(Mandatory = $false)]
+        [string]$NewDisplayName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Description,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('deviceManagement', 'deviceAppManagement')]
+        [string]$PlatformType
+    )
+
+    Write-Verbose "Updating the name and description of Intune policy $ID for customer: $CustomerTenantID"
+
+    if (-not $PSBoundParameters.ContainsKey('NewDisplayName') -and -not $PSBoundParameters.ContainsKey('Description')) {
+        throw 'Provide NewDisplayName, Description, or both.'
+    }
+
+    $endpoint = '/api/EditIntunePolicy'
+    $body = @{
+        tenantFilter = $CustomerTenantID
+        ID           = $ID
+        policyType   = $PolicyType
+    }
+
+    if ($PSBoundParameters.ContainsKey('NewDisplayName')) {
+        $body.newDisplayName = $NewDisplayName
+    }
+
+    if ($PSBoundParameters.ContainsKey('Description')) {
+        $body.description = $Description
+    }
+
+    if ($PSBoundParameters.ContainsKey('PlatformType')) {
+        $body.platformType = $PlatformType
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Body $body -Method POST
+}

--- a/CIPPAPIModule/public/Identity/Administration/Devices/Get-CIPPDetectedAppDevices.ps1
+++ b/CIPPAPIModule/public/Identity/Administration/Devices/Get-CIPPDetectedAppDevices.ps1
@@ -1,0 +1,37 @@
+<#
+.SYNOPSIS
+    Lists Intune-managed devices that have a specific detected application installed, identified by App ID.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListDetectedAppDevices.
+
+.PARAMETER AppID
+    The AppID value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPDetectedAppDevices -AppID '<AppID>' -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPDetectedAppDevices {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$AppID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListDetectedAppDevices from the CIPP API'
+
+    $endpoint = '/api/ListDetectedAppDevices'
+    $params = @{
+        AppID                      = $AppID
+        tenantFilter               = $CustomerTenantID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Identity/Administration/Devices/Get-CIPPDetectedApps.ps1
+++ b/CIPPAPIModule/public/Identity/Administration/Devices/Get-CIPPDetectedApps.ps1
@@ -1,0 +1,44 @@
+<#
+.SYNOPSIS
+    Lists applications detected on Intune-managed devices in a tenant, optionally including device associations.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListDetectedApps.
+
+.PARAMETER DeviceID
+    The DeviceID value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER IncludeDevices
+    The IncludeDevices value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPDetectedApps -DeviceID '<DeviceID>' -CustomerTenantID '<CustomerTenantID>' -IncludeDevices '<IncludeDevices>'
+#>
+function Get-CIPPDetectedApps {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$DeviceID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeDevices
+
+    )
+
+    Write-Verbose 'Retrieving ListDetectedApps from the CIPP API'
+
+    $endpoint = '/api/ListDetectedApps'
+    $params = @{
+        DeviceID                   = $DeviceID
+        tenantFilter               = $CustomerTenantID
+        includeDevices             = $IncludeDevices.IsPresent
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Identity/Administration/Groups/Get-CIPPGroupSenderAuthentication.ps1
+++ b/CIPPAPIModule/public/Identity/Administration/Groups/Get-CIPPGroupSenderAuthentication.ps1
@@ -1,0 +1,44 @@
+<#
+.SYNOPSIS
+    Lists sender authentication settings for an Exchange distribution group or mail-enabled security group, controlling w.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListGroupSenderAuthentication.
+
+.PARAMETER Groupid
+    The Groupid value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER Type
+    The Type value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPGroupSenderAuthentication -Groupid '<Groupid>' -CustomerTenantID '<CustomerTenantID>' -Type '<Type>'
+#>
+function Get-CIPPGroupSenderAuthentication {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$Groupid,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Type
+
+    )
+
+    Write-Verbose 'Retrieving ListGroupSenderAuthentication from the CIPP API'
+
+    $endpoint = '/api/ListGroupSenderAuthentication'
+    $params = @{
+        groupid                    = $Groupid
+        tenantFilter               = $CustomerTenantID
+        Type                       = $Type
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Identity/Administration/Users/Get-CIPPJITAdminTemplates.ps1
+++ b/CIPPAPIModule/public/Identity/Administration/Users/Get-CIPPJITAdminTemplates.ps1
@@ -1,0 +1,47 @@
+<#
+.SYNOPSIS
+    Lists Just-in-Time admin role templates that define temporary admin role assignments.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListJITAdminTemplates.
+
+.PARAMETER IncludeAllTenants
+    The IncludeAllTenants value sent to the CIPP API.
+
+.PARAMETER GUID
+    The GUID value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPJITAdminTemplates -IncludeAllTenants '<IncludeAllTenants>' -GUID '<GUID>' -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPJITAdminTemplates {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeAllTenants,
+
+        [Parameter(Mandatory = $false)]
+        [string]$GUID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListJITAdminTemplates from the CIPP API'
+
+    $endpoint = '/api/ListJITAdminTemplates'
+    $params = @{
+        includeAllTenants          = $IncludeAllTenants.IsPresent
+        GUID                       = $GUID
+        tenantFilter               = $CustomerTenantID
+    }
+
+    $body = @{}
+    if ($PSBoundParameters.ContainsKey('IncludeAllTenants')) { $body['includeAllTenants'] = $IncludeAllTenants.IsPresent }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params -Body $body -Method POST
+}

--- a/CIPPAPIModule/public/Identity/Administration/Users/Get-CIPPNewUserDefaults.ps1
+++ b/CIPPAPIModule/public/Identity/Administration/Users/Get-CIPPNewUserDefaults.ps1
@@ -1,0 +1,47 @@
+<#
+.SYNOPSIS
+    Lists default templates for new user creation, including default domain, usage location, and license assignments.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListNewUserDefaults.
+
+.PARAMETER IncludeAllTenants
+    The IncludeAllTenants value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER ID
+    The ID value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPNewUserDefaults -IncludeAllTenants '<IncludeAllTenants>' -CustomerTenantID '<CustomerTenantID>' -ID '<ID>'
+#>
+function Get-CIPPNewUserDefaults {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeAllTenants,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ID
+
+    )
+
+    Write-Verbose 'Retrieving ListNewUserDefaults from the CIPP API'
+
+    $endpoint = '/api/ListNewUserDefaults'
+    $params = @{
+        includeAllTenants          = $IncludeAllTenants.IsPresent
+        tenantFilter               = $CustomerTenantID
+        ID                         = $ID
+    }
+
+    $body = @{}
+    if ($PSBoundParameters.ContainsKey('IncludeAllTenants')) { $body['includeAllTenants'] = $IncludeAllTenants.IsPresent }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params -Body $body -Method POST
+}

--- a/CIPPAPIModule/public/Identity/Administration/Users/Get-CIPPUserTrustedBlockedSenders.ps1
+++ b/CIPPAPIModule/public/Identity/Administration/Users/Get-CIPPUserTrustedBlockedSenders.ps1
@@ -1,0 +1,44 @@
+<#
+.SYNOPSIS
+    Lists trusted and blocked sender entries configured for a specific user's Exchange Online mailbox junk email settings.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListUserTrustedBlockedSenders.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER UserID
+    The UserID value sent to the CIPP API.
+
+.PARAMETER UserPrincipalName
+    The UserPrincipalName value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPUserTrustedBlockedSenders -CustomerTenantID '<CustomerTenantID>' -UserID '<UserID>' -UserPrincipalName '<UserPrincipalName>'
+#>
+function Get-CIPPUserTrustedBlockedSenders {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$UserID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$UserPrincipalName
+
+    )
+
+    Write-Verbose 'Retrieving ListUserTrustedBlockedSenders from the CIPP API'
+
+    $endpoint = '/api/ListUserTrustedBlockedSenders'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+        UserID                     = $UserID
+        userPrincipalName          = $UserPrincipalName
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Identity/Administration/Users/Get-CIPPUsersAndGroups.ps1
+++ b/CIPPAPIModule/public/Identity/Administration/Users/Get-CIPPUsersAndGroups.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    Lists both users and groups for a tenant in a single batch call, returning ID and display name for selection/lookup p.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListUsersAndGroups.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPUsersAndGroups -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPUsersAndGroups {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListUsersAndGroups from the CIPP API'
+
+    $endpoint = '/api/ListUsersAndGroups'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Identity/Reports/Get-CIPPObjectHistory.ps1
+++ b/CIPPAPIModule/public/Identity/Reports/Get-CIPPObjectHistory.ps1
@@ -1,0 +1,65 @@
+<#
+.SYNOPSIS
+    ListObjectHistory.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListObjectHistory.
+
+.PARAMETER ObjectID
+    The ObjectID value sent to the CIPP API.
+
+.PARAMETER ObjectType
+    The ObjectType value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER Days
+    The Days value sent to the CIPP API.
+
+.PARAMETER ID
+    The ID value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPObjectHistory -ObjectID '<ObjectID>' -ObjectType '<ObjectType>' -CustomerTenantID '<CustomerTenantID>' -Days '<Days>' -ID '<ID>'
+#>
+function Get-CIPPObjectHistory {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [guid]$ObjectID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ObjectType,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [int]$Days,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ID
+
+    )
+
+    Write-Verbose 'Retrieving ListObjectHistory from the CIPP API'
+
+    $endpoint = '/api/ListObjectHistory'
+    $params = @{
+        objectId                   = $ObjectID
+        objectType                 = $ObjectType
+        tenantFilter               = $CustomerTenantID
+        days                       = $Days
+        id                         = $ID
+    }
+
+    $body = @{}
+    $body['objectId'] = $ObjectID
+    if ($PSBoundParameters.ContainsKey('ObjectType')) { $body['objectType'] = $ObjectType }
+    $body['tenantFilter'] = $CustomerTenantID
+    if ($PSBoundParameters.ContainsKey('Days')) { $body['days'] = $Days }
+    if ($PSBoundParameters.ContainsKey('ID')) { $body['id'] = $ID }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Invoke-CIPPRestMethod.ps1
+++ b/CIPPAPIModule/public/Invoke-CIPPRestMethod.ps1
@@ -15,7 +15,7 @@
     Optional. The HTTP method to use for the request. The default value is 'GET'.
 
 .PARAMETER Body
-    Optional. A hashtable representing the request body. It will be converted to JSON before sending the request.
+    Optional. A hashtable representing the request body, or an array of hashtables for endpoints that expect a JSON array. It will be converted to JSON before sending the request.
 
 .PARAMETER ContentType
     Optional. The content type of the request body. The default value is 'application/json'.
@@ -41,7 +41,7 @@ function Invoke-CIPPRestMethod {
         [string]$Endpoint,
         [hashtable]$Params = @{},
         [ValidateSet('GET', 'POST')][string]$Method = 'GET',
-        [hashtable[]]$Body = @{},
+        [object]$Body = @{},
         [string]$ContentType = 'application/json',
         [string]$Authorization = $null
     )

--- a/CIPPAPIModule/public/Invoke-CIPPRestMethod.ps1
+++ b/CIPPAPIModule/public/Invoke-CIPPRestMethod.ps1
@@ -41,6 +41,16 @@ function Invoke-CIPPRestMethod {
         [string]$Endpoint,
         [hashtable]$Params = @{},
         [ValidateSet('GET', 'POST')][string]$Method = 'GET',
+        [ValidateScript({
+            foreach ($item in $_) {
+                # Note: must be the real PSCustomObject class - the [PSCustomObject] accelerator
+                # aliases [PSObject], which matches everything inside ValidateScript.
+                if ($item -isnot [System.Collections.IDictionary] -and $item -isnot [System.Management.Automation.PSCustomObject]) {
+                    throw "Body must be a hashtable/PSCustomObject or an array of them, got [$($item.GetType().Name)]."
+                }
+            }
+            $true
+        })]
         [object]$Body = @{},
         [string]$ContentType = 'application/json',
         [string]$Authorization = $null

--- a/CIPPAPIModule/public/Security/Compliance-DLP/Get-CIPPDlpCompliancePolicy.ps1
+++ b/CIPPAPIModule/public/Security/Compliance-DLP/Get-CIPPDlpCompliancePolicy.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    Lists Data Loss Prevention (DLP) compliance policies and their associated rules from the Security & Compliance Center.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListDlpCompliancePolicy.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPDlpCompliancePolicy -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPDlpCompliancePolicy {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListDlpCompliancePolicy from the CIPP API'
+
+    $endpoint = '/api/ListDlpCompliancePolicy'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Security/Compliance-DLP/Get-CIPPDlpCompliancePolicyTemplates.ps1
+++ b/CIPPAPIModule/public/Security/Compliance-DLP/Get-CIPPDlpCompliancePolicyTemplates.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    Lists saved DLP compliance policy templates for deploying standardized DLP configurations.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListDlpCompliancePolicyTemplates.
+
+.PARAMETER ID
+    The ID value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPDlpCompliancePolicyTemplates -ID '<ID>'
+#>
+function Get-CIPPDlpCompliancePolicyTemplates {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$ID
+
+    )
+
+    Write-Verbose 'Retrieving ListDlpCompliancePolicyTemplates from the CIPP API'
+
+    $endpoint = '/api/ListDlpCompliancePolicyTemplates'
+    $params = @{
+        ID                         = $ID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Security/Compliance-Retention/Get-CIPPRetentionCompliancePolicy.ps1
+++ b/CIPPAPIModule/public/Security/Compliance-Retention/Get-CIPPRetentionCompliancePolicy.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    Lists retention compliance policies and their associated rules from the Security & Compliance Center.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListRetentionCompliancePolicy.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPRetentionCompliancePolicy -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPRetentionCompliancePolicy {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListRetentionCompliancePolicy from the CIPP API'
+
+    $endpoint = '/api/ListRetentionCompliancePolicy'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Security/Compliance-Retention/Get-CIPPRetentionCompliancePolicyTemplates.ps1
+++ b/CIPPAPIModule/public/Security/Compliance-Retention/Get-CIPPRetentionCompliancePolicyTemplates.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    Lists saved retention compliance policy templates for deploying standardized retention configurations.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListRetentionCompliancePolicyTemplates.
+
+.PARAMETER ID
+    The ID value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPRetentionCompliancePolicyTemplates -ID '<ID>'
+#>
+function Get-CIPPRetentionCompliancePolicyTemplates {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$ID
+
+    )
+
+    Write-Verbose 'Retrieving ListRetentionCompliancePolicyTemplates from the CIPP API'
+
+    $endpoint = '/api/ListRetentionCompliancePolicyTemplates'
+    $params = @{
+        ID                         = $ID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Security/Compliance-SIT/Get-CIPPSensitiveInfoType.ps1
+++ b/CIPPAPIModule/public/Security/Compliance-SIT/Get-CIPPSensitiveInfoType.ps1
@@ -1,0 +1,37 @@
+<#
+.SYNOPSIS
+    Lists sensitive information types (SITs) configured in the Security & Compliance Center, optionally including built-i.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListSensitiveInfoType.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER IncludeBuiltIn
+    The IncludeBuiltIn value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPSensitiveInfoType -CustomerTenantID '<CustomerTenantID>' -IncludeBuiltIn '<IncludeBuiltIn>'
+#>
+function Get-CIPPSensitiveInfoType {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$IncludeBuiltIn
+
+    )
+
+    Write-Verbose 'Retrieving ListSensitiveInfoType from the CIPP API'
+
+    $endpoint = '/api/ListSensitiveInfoType'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+        IncludeBuiltIn             = $IncludeBuiltIn
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Security/Compliance-SIT/Get-CIPPSensitiveInfoTypeRulePackage.ps1
+++ b/CIPPAPIModule/public/Security/Compliance-SIT/Get-CIPPSensitiveInfoTypeRulePackage.ps1
@@ -1,0 +1,41 @@
+<#
+.SYNOPSIS
+    ListSensitiveInfoTypeRulePackage.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListSensitiveInfoTypeRulePackage.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER RulePackID
+    The RulePackID value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPSensitiveInfoTypeRulePackage -CustomerTenantID '<CustomerTenantID>' -RulePackID '<RulePackID>'
+#>
+function Get-CIPPSensitiveInfoTypeRulePackage {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$RulePackID
+
+    )
+
+    Write-Verbose 'Retrieving ListSensitiveInfoTypeRulePackage from the CIPP API'
+
+    $endpoint = '/api/ListSensitiveInfoTypeRulePackage'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+        RulePackId                 = $RulePackID
+    }
+
+    $body = @{}
+    $body['tenantFilter'] = $CustomerTenantID
+    if ($PSBoundParameters.ContainsKey('RulePackID')) { $body['RulePackId'] = $RulePackID }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Security/Compliance-SIT/Get-CIPPSensitiveInfoTypeTemplates.ps1
+++ b/CIPPAPIModule/public/Security/Compliance-SIT/Get-CIPPSensitiveInfoTypeTemplates.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    Lists saved sensitive information type templates for deploying custom SIT configurations.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListSensitiveInfoTypeTemplates.
+
+.PARAMETER ID
+    The ID value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPSensitiveInfoTypeTemplates -ID '<ID>'
+#>
+function Get-CIPPSensitiveInfoTypeTemplates {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$ID
+
+    )
+
+    Write-Verbose 'Retrieving ListSensitiveInfoTypeTemplates from the CIPP API'
+
+    $endpoint = '/api/ListSensitiveInfoTypeTemplates'
+    $params = @{
+        ID                         = $ID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Security/Compliance-SensitivityLabel/Get-CIPPSensitivityLabel.ps1
+++ b/CIPPAPIModule/public/Security/Compliance-SensitivityLabel/Get-CIPPSensitivityLabel.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    Lists sensitivity labels and label policies configured in the Security & Compliance Center for a tenant.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListSensitivityLabel.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPSensitivityLabel -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPSensitivityLabel {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListSensitivityLabel from the CIPP API'
+
+    $endpoint = '/api/ListSensitivityLabel'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Security/Compliance-SensitivityLabel/Get-CIPPSensitivityLabelTemplates.ps1
+++ b/CIPPAPIModule/public/Security/Compliance-SensitivityLabel/Get-CIPPSensitivityLabelTemplates.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    Lists saved sensitivity label templates for deploying standardized label configurations.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListSensitivityLabelTemplates.
+
+.PARAMETER ID
+    The ID value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPSensitivityLabelTemplates -ID '<ID>'
+#>
+function Get-CIPPSensitivityLabelTemplates {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$ID
+
+    )
+
+    Write-Verbose 'Retrieving ListSensitivityLabelTemplates from the CIPP API'
+
+    $endpoint = '/api/ListSensitivityLabelTemplates'
+    $params = @{
+        ID                         = $ID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Security/Reports/Get-CIPPSecureScore.ps1
+++ b/CIPPAPIModule/public/Security/Reports/Get-CIPPSecureScore.ps1
@@ -1,0 +1,83 @@
+<#
+.SYNOPSIS
+Retrieves the Microsoft Secure Score for a specified customer tenant.
+
+.DESCRIPTION
+The Get-CIPPSecureScore function queries the Microsoft Secure Score for a customer tenant via
+CIPP and returns the latest snapshot enriched the same way the CIPP portal does: it computes the
+overall percentage and comparative percentages, and joins the per-control breakdown with the
+control profile metadata (title, threats, compliance frameworks).
+
+.PARAMETER CustomerTenantID
+The unique identifier of the customer tenant for which the secure score is retrieved.
+
+.EXAMPLE
+Get-CIPPSecureScore -CustomerTenantID "contoso.onmicrosoft.com"
+#>
+function Get-CIPPSecureScore {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+    )
+
+    Write-Verbose "Getting secure score for $CustomerTenantID."
+    $Endpoint = '/api/ListGraphRequest'
+
+    $Scores = (Invoke-CIPPRestMethod -Endpoint $Endpoint -Params @{
+            tenantFilter = $CustomerTenantID
+            Endpoint     = 'security/secureScores'
+            '$count'     = $true
+            noPagination = $true
+            '$top'       = 7
+        }).Results
+
+    $Latest = $Scores | Select-Object -First 1
+    if (-not $Latest) {
+        Write-Verbose 'No secure score data returned.'
+        return
+    }
+
+    # Profile metadata for control titles/threats/compliance - matched by id == controlName.
+    $Profiles = (Invoke-CIPPRestMethod -Endpoint $Endpoint -Params @{
+            tenantFilter = $CustomerTenantID
+            Endpoint     = 'security/secureScoreControlProfiles'
+            '$count'     = $true
+            '$top'       = 999
+        }).Results
+    $ProfileLookup = @{}
+    foreach ($ControlProfile in $Profiles) { $ProfileLookup[$ControlProfile.id] = $ControlProfile }
+
+    $ControlScores = foreach ($Control in $Latest.controlScores) {
+        $Match = $ProfileLookup[$Control.controlName]
+        [pscustomobject]@{
+            ControlName           = $Control.controlName
+            Title                 = $Match.title
+            ScoreInPercentage     = $Control.scoreInPercentage
+            Score                 = $Control.score
+            Description           = $Control.description
+            Threats               = $Match.threats
+            ComplianceInformation = $Match.complianceInformation
+            Remediation           = $Match.remediation
+            RemediationImpact     = $Match.remediationImpact
+            ImplementationCost    = $Match.implementationCost
+            Tier                  = $Match.tier
+            UserImpact            = $Match.userImpact
+            ActionUrl             = $Match.actionUrl
+            VendorInformation     = $Match.vendorInformation
+            # Portal hides the 'Default' baseline entries; mirror that.
+            ControlStateUpdates   = @($Match.controlStateUpdates | Where-Object { $_.state -ne 'Default' })
+        }
+    }
+
+    [pscustomobject]@{
+        CurrentScore           = $Latest.currentScore
+        MaxScore               = $Latest.maxScore
+        PercentageCurrent      = if ($Latest.maxScore) { [math]::Round(($Latest.currentScore / $Latest.maxScore) * 100) } else { 0 }
+        PercentageVsAllTenants = [math]::Round([double]$Latest.averageComparativeScores[0].averageScore)
+        PercentageVsSimilar    = [math]::Round([double]$Latest.averageComparativeScores[1].averageScore)
+        CreatedDateTime        = $Latest.createdDateTime
+        ControlScores          = $ControlScores
+        History                = $Scores
+    }
+}

--- a/CIPPAPIModule/public/Security/Safe-Links-Policy/Get-CIPPSafeLinksPolicy.ps1
+++ b/CIPPAPIModule/public/Security/Safe-Links-Policy/Get-CIPPSafeLinksPolicy.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    This function is used to list the Safe Links policies in the tenant, including unmatched rules and policies.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListSafeLinksPolicy.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPSafeLinksPolicy -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPSafeLinksPolicy {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListSafeLinksPolicy from the CIPP API'
+
+    $endpoint = '/api/ListSafeLinksPolicy'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Security/Safe-Links-Policy/Get-CIPPSafeLinksPolicyDetails.ps1
+++ b/CIPPAPIModule/public/Security/Safe-Links-Policy/Get-CIPPSafeLinksPolicyDetails.ps1
@@ -1,0 +1,49 @@
+<#
+.SYNOPSIS
+    This function retrieves details for a specific Safe Links policy and rule.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListSafeLinksPolicyDetails.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER PolicyName
+    The PolicyName value sent to the CIPP API.
+
+.PARAMETER RuleName
+    The RuleName value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPSafeLinksPolicyDetails -CustomerTenantID '<CustomerTenantID>' -PolicyName '<PolicyName>' -RuleName '<RuleName>'
+#>
+function Get-CIPPSafeLinksPolicyDetails {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$PolicyName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$RuleName
+
+    )
+
+    Write-Verbose 'Retrieving ListSafeLinksPolicyDetails from the CIPP API'
+
+    $endpoint = '/api/ListSafeLinksPolicyDetails'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+        PolicyName                 = $PolicyName
+        RuleName                   = $RuleName
+    }
+
+    $body = @{}
+    $body['tenantFilter'] = $CustomerTenantID
+    if ($PSBoundParameters.ContainsKey('PolicyName')) { $body['PolicyName'] = $PolicyName }
+    if ($PSBoundParameters.ContainsKey('RuleName')) { $body['RuleName'] = $RuleName }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params -Body $body -Method POST
+}

--- a/CIPPAPIModule/public/Security/Safe-Links-Policy/Get-CIPPSafeLinksPolicyTemplateDetails.ps1
+++ b/CIPPAPIModule/public/Security/Safe-Links-Policy/Get-CIPPSafeLinksPolicyTemplateDetails.ps1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+    This function retrieves details for a specific Safe Links policy template.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListSafeLinksPolicyTemplateDetails.
+
+.PARAMETER ID
+    The ID value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPSafeLinksPolicyTemplateDetails -ID '<ID>'
+#>
+function Get-CIPPSafeLinksPolicyTemplateDetails {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$ID
+
+    )
+
+    Write-Verbose 'Retrieving ListSafeLinksPolicyTemplateDetails from the CIPP API'
+
+    $endpoint = '/api/ListSafeLinksPolicyTemplateDetails'
+    $params = @{
+        ID                         = $ID
+    }
+
+    $body = @{}
+    if ($PSBoundParameters.ContainsKey('ID')) { $body['ID'] = $ID }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params -Body $body -Method POST
+}

--- a/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPDeletedSites.ps1
+++ b/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPDeletedSites.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    ListDeletedSites.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListDeletedSites.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPDeletedSites -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPDeletedSites {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListDeletedSites from the CIPP API'
+
+    $endpoint = '/api/ListDeletedSites'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPSPOVersionCleanup.ps1
+++ b/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPSPOVersionCleanup.ps1
@@ -1,0 +1,41 @@
+<#
+.SYNOPSIS
+    ListSPOVersionCleanup.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListSPOVersionCleanup.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER SiteURL
+    The SiteURL value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPSPOVersionCleanup -CustomerTenantID '<CustomerTenantID>' -SiteURL '<SiteURL>'
+#>
+function Get-CIPPSPOVersionCleanup {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$SiteURL
+
+    )
+
+    Write-Verbose 'Retrieving ListSPOVersionCleanup from the CIPP API'
+
+    $endpoint = '/api/ListSPOVersionCleanup'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+        SiteUrl                    = $SiteURL
+    }
+
+    $body = @{}
+    $body['tenantFilter'] = $CustomerTenantID
+    if ($PSBoundParameters.ContainsKey('SiteURL')) { $body['SiteUrl'] = $SiteURL }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPSharePointExternalUsers.ps1
+++ b/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPSharePointExternalUsers.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    ListSharePointExternalUsers.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListSharePointExternalUsers.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPSharePointExternalUsers -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPSharePointExternalUsers {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListSharePointExternalUsers from the CIPP API'
+
+    $endpoint = '/api/ListSharePointExternalUsers'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPSharePointSharing.ps1
+++ b/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPSharePointSharing.ps1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+    ListSharePointSharing.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListSharePointSharing.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPSharePointSharing -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPSharePointSharing {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListSharePointSharing from the CIPP API'
+
+    $endpoint = '/api/ListSharePointSharing'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+    }
+
+    $body = @{}
+    $body['tenantFilter'] = $CustomerTenantID
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPSiteLibraries.ps1
+++ b/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPSiteLibraries.ps1
@@ -1,0 +1,49 @@
+<#
+.SYNOPSIS
+    ListSiteLibraries.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListSiteLibraries.
+
+.PARAMETER SiteID
+    The SiteID value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER SiteURL
+    The SiteURL value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPSiteLibraries -SiteID '<SiteID>' -CustomerTenantID '<CustomerTenantID>' -SiteURL '<SiteURL>'
+#>
+function Get-CIPPSiteLibraries {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$SiteID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$SiteURL
+
+    )
+
+    Write-Verbose 'Retrieving ListSiteLibraries from the CIPP API'
+
+    $endpoint = '/api/ListSiteLibraries'
+    $params = @{
+        SiteId                     = $SiteID
+        tenantFilter               = $CustomerTenantID
+        SiteUrl                    = $SiteURL
+    }
+
+    $body = @{}
+    if ($PSBoundParameters.ContainsKey('SiteID')) { $body['SiteId'] = $SiteID }
+    $body['tenantFilter'] = $CustomerTenantID
+    if ($PSBoundParameters.ContainsKey('SiteURL')) { $body['SiteUrl'] = $SiteURL }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPSiteMembers.ps1
+++ b/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPSiteMembers.ps1
@@ -1,0 +1,51 @@
+<#
+.SYNOPSIS
+    Lists members of a specific SharePoint site by site ID, including user display names and email addresses.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListSiteMembers.
+
+.PARAMETER SiteID
+    The SiteID value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER Filter
+    The Filter value sent to the CIPP API.
+
+.PARAMETER SiteURL
+    The SiteURL value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPSiteMembers -SiteID '<SiteID>' -CustomerTenantID '<CustomerTenantID>' -Filter '<Filter>' -SiteURL '<SiteURL>'
+#>
+function Get-CIPPSiteMembers {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$SiteID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Filter,
+
+        [Parameter(Mandatory = $false)]
+        [string]$SiteURL
+
+    )
+
+    Write-Verbose 'Retrieving ListSiteMembers from the CIPP API'
+
+    $endpoint = '/api/ListSiteMembers'
+    $params = @{
+        SiteId                     = $SiteID
+        tenantFilter               = $CustomerTenantID
+        Filter                     = $Filter
+        SiteUrl                    = $SiteURL
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPSiteProperties.ps1
+++ b/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPSiteProperties.ps1
@@ -1,0 +1,37 @@
+<#
+.SYNOPSIS
+    ListSiteProperties.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListSiteProperties.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER SiteURL
+    The SiteURL value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPSiteProperties -CustomerTenantID '<CustomerTenantID>' -SiteURL '<SiteURL>'
+#>
+function Get-CIPPSiteProperties {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$SiteURL
+
+    )
+
+    Write-Verbose 'Retrieving ListSiteProperties from the CIPP API'
+
+    $endpoint = '/api/ListSiteProperties'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+        SiteUrl                    = $SiteURL
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPSiteRecycleBin.ps1
+++ b/CIPPAPIModule/public/Teams-Sharepoint/Sharepoint/Get-CIPPSiteRecycleBin.ps1
@@ -1,0 +1,37 @@
+<#
+.SYNOPSIS
+    ListSiteRecycleBin.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListSiteRecycleBin.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER SiteURL
+    The SiteURL value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPSiteRecycleBin -CustomerTenantID '<CustomerTenantID>' -SiteURL '<SiteURL>'
+#>
+function Get-CIPPSiteRecycleBin {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$SiteURL
+
+    )
+
+    Write-Verbose 'Retrieving ListSiteRecycleBin from the CIPP API'
+
+    $endpoint = '/api/ListSiteRecycleBin'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+        SiteUrl                    = $SiteURL
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Tenant/Administration/Alerts/Get-CIPPAuditLogCoverage.ps1
+++ b/CIPPAPIModule/public/Tenant/Administration/Alerts/Get-CIPPAuditLogCoverage.ps1
@@ -1,0 +1,57 @@
+<#
+.SYNOPSIS
+    ListAuditLogCoverage.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListAuditLogCoverage.
+
+.PARAMETER RelativeTime
+    The RelativeTime value sent to the CIPP API.
+
+.PARAMETER EndDate
+    The EndDate value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER StartDate
+    The StartDate value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPAuditLogCoverage -RelativeTime '<RelativeTime>' -EndDate '<EndDate>' -CustomerTenantID '<CustomerTenantID>' -StartDate '<StartDate>'
+#>
+function Get-CIPPAuditLogCoverage {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$RelativeTime,
+
+        [Parameter(Mandatory = $false)]
+        [string]$EndDate,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$StartDate
+
+    )
+
+    Write-Verbose 'Retrieving ListAuditLogCoverage from the CIPP API'
+
+    $endpoint = '/api/ListAuditLogCoverage'
+    $params = @{
+        RelativeTime               = $RelativeTime
+        EndDate                    = $EndDate
+        tenantFilter               = $CustomerTenantID
+        StartDate                  = $StartDate
+    }
+
+    $body = @{}
+    if ($PSBoundParameters.ContainsKey('RelativeTime')) { $body['RelativeTime'] = $RelativeTime }
+    if ($PSBoundParameters.ContainsKey('EndDate')) { $body['EndDate'] = $EndDate }
+    $body['tenantFilter'] = $CustomerTenantID
+    if ($PSBoundParameters.ContainsKey('StartDate')) { $body['StartDate'] = $StartDate }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Tenant/Administration/Get-CIPPOffboardTenants.ps1
+++ b/CIPPAPIModule/public/Tenant/Administration/Get-CIPPOffboardTenants.ps1
@@ -1,0 +1,19 @@
+<#
+.SYNOPSIS
+    Lists tenants available for offboarding, including tenants in error state.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListOffboardTenants.
+
+.EXAMPLE
+    Get-CIPPOffboardTenants
+#>
+function Get-CIPPOffboardTenants {
+    [CmdletBinding()]
+    param ()
+
+    Write-Verbose 'Retrieving ListOffboardTenants from the CIPP API'
+
+    $endpoint = '/api/ListOffboardTenants'
+    Invoke-CIPPRestMethod -Endpoint $endpoint
+}

--- a/CIPPAPIModule/public/Tenant/Administration/Tenant/Get-CIPPCustomVariables.ps1
+++ b/CIPPAPIModule/public/Tenant/Administration/Tenant/Get-CIPPCustomVariables.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Retrieves custom variables for a specified tenant from the CIPP system.
 

--- a/CIPPAPIModule/public/Tenant/GDAP/Get-CIPPGDAPContracts.ps1
+++ b/CIPPAPIModule/public/Tenant/GDAP/Get-CIPPGDAPContracts.ps1
@@ -1,0 +1,19 @@
+<#
+.SYNOPSIS
+    Lists Microsoft partner contracts (customer tenant relationships) from the Graph API.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListGDAPContracts.
+
+.EXAMPLE
+    Get-CIPPGDAPContracts
+#>
+function Get-CIPPGDAPContracts {
+    [CmdletBinding()]
+    param ()
+
+    Write-Verbose 'Retrieving ListGDAPContracts from the CIPP API'
+
+    $endpoint = '/api/ListGDAPContracts'
+    Invoke-CIPPRestMethod -Endpoint $endpoint
+}

--- a/CIPPAPIModule/public/Tenant/GDAP/Get-CIPPGDAPRelationships.ps1
+++ b/CIPPAPIModule/public/Tenant/GDAP/Get-CIPPGDAPRelationships.ps1
@@ -1,0 +1,61 @@
+<#
+.SYNOPSIS
+    Lists GDAP delegated admin relationships with customer tenants, with optional filtering by relationship ID or OData f.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListGDAPRelationships.
+
+.PARAMETER ID
+    The ID value sent to the CIPP API.
+
+.PARAMETER StandardsExcludeAllTenants
+    The StandardsExcludeAllTenants value sent to the CIPP API.
+
+.PARAMETER IgnoreMissingRoles
+    The IgnoreMissingRoles value sent to the CIPP API.
+
+.PARAMETER RemapRoles
+    The RemapRoles value sent to the CIPP API.
+
+.PARAMETER GDAPRoles
+    The GDAPRoles value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPGDAPRelationships -ID '<ID>' -StandardsExcludeAllTenants '<StandardsExcludeAllTenants>' -IgnoreMissingRoles '<IgnoreMissingRoles>' -RemapRoles '<RemapRoles>' -GDAPRoles '<GDAPRoles>'
+#>
+function Get-CIPPGDAPRelationships {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$ID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$StandardsExcludeAllTenants,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$IgnoreMissingRoles,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$RemapRoles,
+
+        [Parameter(Mandatory = $false)]
+        [string]$GDAPRoles
+
+    )
+
+    Write-Verbose 'Retrieving ListGDAPRelationships from the CIPP API'
+
+    $endpoint = '/api/ListGDAPRelationships'
+    $params = @{
+        id                         = $ID
+    }
+
+    $body = @{}
+    if ($PSBoundParameters.ContainsKey('StandardsExcludeAllTenants')) { $body['standardsExcludeAllTenants'] = $StandardsExcludeAllTenants }
+    if ($PSBoundParameters.ContainsKey('IgnoreMissingRoles')) { $body['ignoreMissingRoles'] = $IgnoreMissingRoles.IsPresent }
+    if ($PSBoundParameters.ContainsKey('RemapRoles')) { $body['remapRoles'] = $RemapRoles.IsPresent }
+    if ($PSBoundParameters.ContainsKey('GDAPRoles')) { $body['gdapRoles'] = $GDAPRoles }
+    if ($PSBoundParameters.ContainsKey('ID')) { $body['id'] = $ID }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Tenant/GDAP/Get-CIPPGDAPServicePrincipals.ps1
+++ b/CIPPAPIModule/public/Tenant/GDAP/Get-CIPPGDAPServicePrincipals.ps1
@@ -1,0 +1,44 @@
+<#
+.SYNOPSIS
+    Lists service principals in a customer tenant owned by the partner or specified vendor tenant IDs, useful for identif.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListGDAPServicePrincipals.
+
+.PARAMETER VendorTenantIds
+    The VendorTenantIds value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER OwnerType
+    The OwnerType value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPGDAPServicePrincipals -VendorTenantIds '<VendorTenantIds>' -CustomerTenantID '<CustomerTenantID>' -OwnerType '<OwnerType>'
+#>
+function Get-CIPPGDAPServicePrincipals {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$VendorTenantIds,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$OwnerType
+
+    )
+
+    Write-Verbose 'Retrieving ListGDAPServicePrincipals from the CIPP API'
+
+    $endpoint = '/api/ListGDAPServicePrincipals'
+    $params = @{
+        vendorTenantIds            = $VendorTenantIds
+        tenantFilter               = $CustomerTenantID
+        ownerType                  = $OwnerType
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Tenant/GDAP/Get-CIPPResellerRelationshipLink.ps1
+++ b/CIPPAPIModule/public/Tenant/GDAP/Get-CIPPResellerRelationshipLink.ps1
@@ -1,0 +1,19 @@
+<#
+.SYNOPSIS
+    Retrieves the indirect reseller relationship invitation link from Partner Center for onboarding new customer tenants.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListResellerRelationshipLink.
+
+.EXAMPLE
+    Get-CIPPResellerRelationshipLink
+#>
+function Get-CIPPResellerRelationshipLink {
+    [CmdletBinding()]
+    param ()
+
+    Write-Verbose 'Retrieving ListResellerRelationshipLink from the CIPP API'
+
+    $endpoint = '/api/ListResellerRelationshipLink'
+    Invoke-CIPPRestMethod -Endpoint $endpoint
+}

--- a/CIPPAPIModule/public/Tenant/Reports/Get-CIPPGraphReports.ps1
+++ b/CIPPAPIModule/public/Tenant/Reports/Get-CIPPGraphReports.ps1
@@ -1,0 +1,51 @@
+<#
+.SYNOPSIS
+    Retrieves Microsoft 365 usage reports (Graph or Office reports) for a tenant, such as email activity, OneDrive usage,.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListGraphReports.
+
+.PARAMETER Period
+    The Period value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER Report
+    The Report value sent to the CIPP API.
+
+.PARAMETER Type
+    The Type value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPGraphReports -Period '<Period>' -CustomerTenantID '<CustomerTenantID>' -Report '<Report>' -Type '<Type>'
+#>
+function Get-CIPPGraphReports {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$Period,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Report,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Type
+
+    )
+
+    Write-Verbose 'Retrieving ListGraphReports from the CIPP API'
+
+    $endpoint = '/api/ListGraphReports'
+    $params = @{
+        period                     = $Period
+        tenantFilter               = $CustomerTenantID
+        report                     = $Report
+        type                       = $Type
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Tenant/Reports/Get-CIPPLicensesReport.ps1
+++ b/CIPPAPIModule/public/Tenant/Reports/Get-CIPPLicensesReport.ps1
@@ -1,0 +1,37 @@
+<#
+.SYNOPSIS
+    Lists a detailed license overview across all tenants or a single tenant, including SKU breakdowns, costs, and availab.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListLicensesReport.
+
+.PARAMETER QueueID
+    The QueueID value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPLicensesReport -QueueID '<QueueID>' -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPLicensesReport {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$QueueID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListLicensesReport from the CIPP API'
+
+    $endpoint = '/api/ListLicensesReport'
+    $params = @{
+        QueueId                    = $QueueID
+        tenantFilter               = $CustomerTenantID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Tenant/Reports/Get-CIPPTestReports.ps1
+++ b/CIPPAPIModule/public/Tenant/Reports/Get-CIPPTestReports.ps1
@@ -1,0 +1,19 @@
+<#
+.SYNOPSIS
+    Lists all available test reports from JSON files and database.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListTestReports.
+
+.EXAMPLE
+    Get-CIPPTestReports
+#>
+function Get-CIPPTestReports {
+    [CmdletBinding()]
+    param ()
+
+    Write-Verbose 'Retrieving ListTestReports from the CIPP API'
+
+    $endpoint = '/api/ListTestReports'
+    Invoke-CIPPRestMethod -Endpoint $endpoint
+}

--- a/CIPPAPIModule/public/Tenant/Reports/Get-CIPPTestResultsTenants.ps1
+++ b/CIPPAPIModule/public/Tenant/Reports/Get-CIPPTestResultsTenants.ps1
@@ -1,0 +1,73 @@
+<#
+.SYNOPSIS
+    ListTestResultsTenants.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListTestResultsTenants.
+
+.PARAMETER Category
+    The Category value sent to the CIPP API.
+
+.PARAMETER TestType
+    The TestType value sent to the CIPP API.
+
+.PARAMETER Status
+    The Status value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER Risk
+    The Risk value sent to the CIPP API.
+
+.PARAMETER TestID
+    The TestID value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPTestResultsTenants -Category '<Category>' -TestType '<TestType>' -Status '<Status>' -CustomerTenantID '<CustomerTenantID>' -Risk '<Risk>' -TestID '<TestID>'
+#>
+function Get-CIPPTestResultsTenants {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$Category,
+
+        [Parameter(Mandatory = $false)]
+        [string]$TestType,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Status,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Risk,
+
+        [Parameter(Mandatory = $false)]
+        [string]$TestID
+
+    )
+
+    Write-Verbose 'Retrieving ListTestResultsTenants from the CIPP API'
+
+    $endpoint = '/api/ListTestResultsTenants'
+    $params = @{
+        category                   = $Category
+        testType                   = $TestType
+        status                     = $Status
+        tenantFilter               = $CustomerTenantID
+        risk                       = $Risk
+        testId                     = $TestID
+    }
+
+    $body = @{}
+    if ($PSBoundParameters.ContainsKey('Category')) { $body['category'] = $Category }
+    if ($PSBoundParameters.ContainsKey('TestType')) { $body['testType'] = $TestType }
+    if ($PSBoundParameters.ContainsKey('Status')) { $body['status'] = $Status }
+    $body['tenantFilter'] = $CustomerTenantID
+    if ($PSBoundParameters.ContainsKey('Risk')) { $body['risk'] = $Risk }
+    if ($PSBoundParameters.ContainsKey('TestID')) { $body['testId'] = $TestID }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Tenant/Reports/Get-CIPPTests.ps1
+++ b/CIPPAPIModule/public/Tenant/Reports/Get-CIPPTests.ps1
@@ -1,0 +1,41 @@
+<#
+.SYNOPSIS
+    Lists tests for a tenant, optionally filtered by report ID.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListTests.
+
+.PARAMETER ReportID
+    The ReportID value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPTests -ReportID '<ReportID>' -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPTests {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$ReportID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListTests from the CIPP API'
+
+    $endpoint = '/api/ListTests'
+    $params = @{
+        reportId                   = $ReportID
+        tenantFilter               = $CustomerTenantID
+    }
+
+    $body = @{}
+    if ($PSBoundParameters.ContainsKey('ReportID')) { $body['reportId'] = $ReportID }
+    $body['tenantFilter'] = $CustomerTenantID
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params -Body $body -Method POST
+}

--- a/CIPPAPIModule/public/Tenant/Standards/Get-CIPPAgent365PackageDetail.ps1
+++ b/CIPPAPIModule/public/Tenant/Standards/Get-CIPPAgent365PackageDetail.ps1
@@ -1,0 +1,41 @@
+<#
+.SYNOPSIS
+    ListAgent365PackageDetail.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListAgent365PackageDetail.
+
+.PARAMETER ID
+    The ID value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPAgent365PackageDetail -ID '<ID>' -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPAgent365PackageDetail {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$ID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListAgent365PackageDetail from the CIPP API'
+
+    $endpoint = '/api/ListAgent365PackageDetail'
+    $params = @{
+        id                         = $ID
+        tenantFilter               = $CustomerTenantID
+    }
+
+    $body = @{}
+    $body['id'] = $ID
+    $body['tenantFilter'] = $CustomerTenantID
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Tenant/Standards/Get-CIPPAgent365Packages.ps1
+++ b/CIPPAPIModule/public/Tenant/Standards/Get-CIPPAgent365Packages.ps1
@@ -1,0 +1,41 @@
+<#
+.SYNOPSIS
+    ListAgent365Packages.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListAgent365Packages.
+
+.PARAMETER Filter
+    The Filter value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPAgent365Packages -Filter '<Filter>' -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPAgent365Packages {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$Filter,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListAgent365Packages from the CIPP API'
+
+    $endpoint = '/api/ListAgent365Packages'
+    $params = @{
+        Filter                     = $Filter
+        tenantFilter               = $CustomerTenantID
+    }
+
+    $body = @{}
+    if ($PSBoundParameters.ContainsKey('Filter')) { $body['Filter'] = $Filter }
+    $body['tenantFilter'] = $CustomerTenantID
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Tenant/Standards/Get-CIPPCopilotSettings.ps1
+++ b/CIPPAPIModule/public/Tenant/Standards/Get-CIPPCopilotSettings.ps1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+    ListCopilotSettings.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListCopilotSettings.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPCopilotSettings -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPCopilotSettings {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListCopilotSettings from the CIPP API'
+
+    $endpoint = '/api/ListCopilotSettings'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+    }
+
+    $body = @{}
+    $body['tenantFilter'] = $CustomerTenantID
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Tenant/Standards/Get-CIPPCopilotUsage.ps1
+++ b/CIPPAPIModule/public/Tenant/Standards/Get-CIPPCopilotUsage.ps1
@@ -1,0 +1,49 @@
+<#
+.SYNOPSIS
+    ListCopilotUsage.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListCopilotUsage.
+
+.PARAMETER Period
+    The Period value sent to the CIPP API.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.PARAMETER Type
+    The Type value sent to the CIPP API.
+
+.EXAMPLE
+    Get-CIPPCopilotUsage -Period '<Period>' -CustomerTenantID '<CustomerTenantID>' -Type '<Type>'
+#>
+function Get-CIPPCopilotUsage {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$Period,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Type
+
+    )
+
+    Write-Verbose 'Retrieving ListCopilotUsage from the CIPP API'
+
+    $endpoint = '/api/ListCopilotUsage'
+    $params = @{
+        period                     = $Period
+        tenantFilter               = $CustomerTenantID
+        Type                       = $Type
+    }
+
+    $body = @{}
+    if ($PSBoundParameters.ContainsKey('Period')) { $body['period'] = $Period }
+    $body['tenantFilter'] = $CustomerTenantID
+    if ($PSBoundParameters.ContainsKey('Type')) { $body['Type'] = $Type }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Tenant/Standards/Get-CIPPShadowAI.ps1
+++ b/CIPPAPIModule/public/Tenant/Standards/Get-CIPPShadowAI.ps1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+    ListShadowAI.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListShadowAI.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPShadowAI -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPShadowAI {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListShadowAI from the CIPP API'
+
+    $endpoint = '/api/ListShadowAI'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+    }
+
+    $body = @{}
+    $body['tenantFilter'] = $CustomerTenantID
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/CIPPAPIModule/public/Tenant/Standards/Get-CIPPStandardsCurrentState.ps1
+++ b/CIPPAPIModule/public/Tenant/Standards/Get-CIPPStandardsCurrentState.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    Lists the current remediation state of standards applied to a specific tenant, including last check results.
+
+.DESCRIPTION
+    Retrieves data from the CIPP API endpoint /api/ListStandardsCurrentState.
+
+.PARAMETER CustomerTenantID
+    The customer tenant domain or GUID to query.
+
+.EXAMPLE
+    Get-CIPPStandardsCurrentState -CustomerTenantID '<CustomerTenantID>'
+#>
+function Get-CIPPStandardsCurrentState {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CustomerTenantID
+
+    )
+
+    Write-Verbose 'Retrieving ListStandardsCurrentState from the CIPP API'
+
+    $endpoint = '/api/ListStandardsCurrentState'
+    $params = @{
+        tenantFilter               = $CustomerTenantID
+    }
+
+    Invoke-CIPPRestMethod -Endpoint $endpoint -Params $params
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## What is this?
 
-This is the code for a [PowerShell](https://microsoft.com/powershell) module for [CIPP](https://cipp.app/). It is a work in progress, and only has about 207 out of the almost 350 API Endpoints built in. However, more will follow and it does have a generic 'Invoke-CIPPRestMethod' available so you can make any API call you want. See advanced usage examples below.
+This is the code for a [PowerShell](https://microsoft.com/powershell) module for [CIPP](https://cipp.app/). It is a work in progress, and only has about 350 out of the about 600 API Endpoints built in. However, more will follow and it does have a generic 'Invoke-CIPPRestMethod' available so you can make any API call you want. See advanced usage examples below.
 
 The module is written for [PowerShell 7](https://docs.microsoft.com/en-us/powershell/scripting/whats-new/what-s-new-in-powershell-71?view=powershell-7.1).
 
@@ -73,14 +73,15 @@ Some example scripts can be found Below:
 - [Get-AllTenants-SoftDeletedMailboxes.ps1](./Example%20Scripts/Get-AllTenants-SoftDeletedMailboxes.ps1)
 - [Get-AllTenants-LicensedUsers.ps1](./Example%20Scripts/Get-AllTenants-LicensedUsers.ps1)
 
-
 ## Assigning Yourself an Issue
 
-If you want to help by fixing a bug or implementing a feature request from an open issue, you can assign yourself the issue by creating a comment that says `I would like to work on this please!`. 
+If you want to help by fixing a bug or implementing a feature request from an open issue, you can assign yourself the issue by creating a comment that says `I would like to work on this please!`.
 You must enter that text exactly, otherwise the assignment does not trigger.
 
 # Cmdlet Help
+
 ## CIPP
+
 - Core
   - [Get-CIPPAccessCheck](./Docs/Get-CIPPAccessCheck.md)
   - [Get-CIPPAdminPortalLicenses](./Docs/Get-CIPPAdminPortalLicenses.md)
@@ -176,7 +177,9 @@ You must enter that text exactly, otherwise the assignment does not trigger.
 - [Set-CIPPPasswordSettings](./Docs/Set-CIPPPasswordSettings.md)
 - [Set-CIPPTenantGroup](./Docs/Set-CIPPTenantGroup.md)
 - [Get-CIPPPendingWebhooks](./Docs/Get-CIPPPendingWebhooks.md)
+
 ## Email
+
 - Administration
   - [Add-CIPPContact](./Docs/Add-CIPPContact.md)
   - [Add-CIPPExchConnector](./Docs/Add-CIPPExchConnector.md)
@@ -341,7 +344,9 @@ You must enter that text exactly, otherwise the assignment does not trigger.
 - [Remove-CIPPTransportRuleTemplate](./Docs/Remove-CIPPTransportRuleTemplate.md)
 - [Set-CIPPExchConnector](./Docs/Set-CIPPExchConnector.md)
 - [Set-CIPPTransportRule](./Docs/Set-CIPPTransportRule.md)
+
 ## Endpoint
+
 - Applications
   - [Get-CIPPApps](./Docs/Get-CIPPApps.md)
   - [Get-CIPPAppsRepository](./Docs/Get-CIPPAppsRepository.md)
@@ -418,7 +423,9 @@ You must enter that text exactly, otherwise the assignment does not trigger.
 - [Set-CIPPMEMPolicy](./Docs/Set-CIPPMEMPolicy.md)
 - [Sync-CIPPDEPTokens](./Docs/Sync-CIPPDEPTokens.md)
 - [Get-CIPPDevices](./Docs/Get-CIPPDevices.md)
+
 ## Extensions
+
 - HaloPSA
   - [Get-CIPPHaloClients](./Docs/Get-CIPPHaloClients.md)
   - [Set-CIPPExtensionMappingHaloPSA](./Docs/Set-CIPPExtensionMappingHaloPSA.md)
@@ -431,7 +438,9 @@ You must enter that text exactly, otherwise the assignment does not trigger.
 - [Set-CIPPExtensionMappingHaloPSA](./Docs/Set-CIPPExtensionMappingHaloPSA.md)
 - [Set-CIPPNinjaOneQueue](./Docs/Set-CIPPNinjaOneQueue.md)
 - [Get-CIPPExtensionsConfig](./Docs/Get-CIPPExtensionsConfig.md)
+
 ## Identity
+
 - Administration
   - [Devices](./Docs/Devices.md)
   - [Groups](./Docs/Groups.md)
@@ -526,7 +535,9 @@ You must enter that text exactly, otherwise the assignment does not trigger.
 - [Get-CIPPInactiveAccounts](./Docs/Get-CIPPInactiveAccounts.md)
 - [Get-CIPPMFAUsers](./Docs/Get-CIPPMFAUsers.md)
 - [Get-CIPPSignIns](./Docs/Get-CIPPSignIns.md)
+
 ## Security
+
 - Defender
   - [Get-CIPPDefenderOnboarding](./Docs/Get-CIPPDefenderOnboarding.md)
   - [Get-CIPPDefenderState](./Docs/Get-CIPPDefenderState.md)
@@ -554,13 +565,19 @@ You must enter that text exactly, otherwise the assignment does not trigger.
 - [Get-CIPPBreachesTenant](./Docs/Get-CIPPBreachesTenant.md)
 - [Get-CIPPBreachSearch](./Docs/Get-CIPPBreachSearch.md)
 - [Get-CIPPDeviceCompliance](./Docs/Get-CIPPDeviceCompliance.md)
+
 ## Settings
+
 - [Invoke-CIPPSchedulerBillingRun](./Docs/Invoke-CIPPSchedulerBillingRun.md)
+
 ## Teams
+
 - Voice
   - [Get-CIPPTeamsLisLocation](./Docs/Get-CIPPTeamsLisLocation.md)
 - [Get-CIPPTeamsLisLocation](./Docs/Get-CIPPTeamsLisLocation.md)
+
 ## Teams-Sharepoint
+
 - OneDrive
   - [Get-CIPPOneDriveList](./Docs/Get-CIPPOneDriveList.md)
   - [Set-CIPPOneDrivePerms](./Docs/Set-CIPPOneDrivePerms.md)
@@ -591,7 +608,9 @@ You must enter that text exactly, otherwise the assignment does not trigger.
 - [Get-CIPPTeams](./Docs/Get-CIPPTeams.md)
 - [Get-CIPPTeamsActivity](./Docs/Get-CIPPTeamsActivity.md)
 - [Get-CIPPTeamsVoice](./Docs/Get-CIPPTeamsVoice.md)
+
 ## Tenant
+
 - Administration
   - [Alerts](./Docs/Alerts.md)
   - [Applications](./Docs/Applications.md)
@@ -720,16 +739,15 @@ You must enter that text exactly, otherwise the assignment does not trigger.
 - [Get-CIPPExternalGEOIPLookup](./Docs/Get-CIPPExternalGEOIPLookup.md)
 - [Get-CIPPExternalTenantInfo](./Docs/Get-CIPPExternalTenantInfo.md)
 - [Get-CIPPGraphRequest](./Docs/Get-CIPPGraphRequest.md)
+
 ## Invoke-CIPPRestMethod
+
 - [Invoke-CIPPRestMethod](./Docs/Invoke-CIPPRestMethod.md)
+
 ## Set-CIPPAPIDetails
+
 - [Set-CIPPAPIDetails](./Docs/Set-CIPPAPIDetails.md)
 
 ##Special Thanks
 
 Special thanks to @KelvinTegelaar, @JohnDuprey, @rvdwegen and @Jr7468. I Could not have got this far without you!
-
-
-
-
-

--- a/Tools/Get-CIPPEndpoints.ps1
+++ b/Tools/Get-CIPPEndpoints.ps1
@@ -3,8 +3,8 @@ Set-Location ..
 Set-Location ..
 
 
-$AllCippEndpoints = Get-ChildItem -Path 'CIPP-API\Modules\CIPPCore\Public' -Recurse -Filter 'Invoke-*.ps1' -File | Where-Object { $_.Name -notlike '*CIPPStandard*' }
-$AllCippApiModuleEndpoints = Get-ChildItem -Path 'CIPPAPIModule\CIPPAPIModule\public' -Recurse -File
+$AllCippEndpoints = Get-ChildItem -Path '.\CIPP-API\Modules\CIPPHTTP\Public' -Recurse -Filter 'Invoke-*.ps1' -File
+$AllCippApiModuleEndpoints = Get-ChildItem -Path '.\CIPPAPIModule\CIPPAPIModule\public' -Recurse -File
 
 $IgnoredEndpoints = @(
     'Invoke-ExecListAppId' # This endpoint is used in the SAM setup and it might be a bad idea to have it in the CIPP API Module


### PR DESCRIPTION
## Problem

Fixes #100.

#91 changed `Invoke-CIPPRestMethod`'s `$Body` parameter from `[hashtable]` to `[hashtable[]]` to support posting an array of mappings. Side effect: PowerShell coerces every single-hashtable body into a one-element array at binding, and since serialization uses `ConvertTo-Json -InputObject` (which preserves array wrapping), every POST body has shipped as `[{...}]` instead of `{...}` since then.

Most CIPP endpoints tolerate this by accident — member enumeration makes property *reads* on a 1-element array work — but endpoints that *set* properties on the parsed body fail, e.g. `AddScheduledItem`:

> Could not add task: The property 'ScheduledTime' cannot be found on this object.

## Fix

`[hashtable[]]$Body` → `[object]$Body`, which removes the coercion. With `-InputObject`, every shape now serializes correctly:

| Input | Before | After |
|---|---|---|
| `@{a=1}` | `[{"a":1}]` ❌ | `{"a":1}` ✅ fixes #100 |
| `@( @{a=1}, @{b=2} )` | `[{...},{...}]` | `[{...},{...}]` ✅ #91 use case preserved |
| `@( ,@{a=1} )` | `[{"a":1}]` | `[{"a":1}]` ✅ |
| `[pscustomobject]@{a=1}` | binding error | `{"a":1}` ✅ bonus |

Since `[object]` alone would silently accept anything (an int, or worse, a pre-serialized JSON string that would get double-encoded to `"{\"a\":1}"`), a `ValidateScript` rejects non-hashtable/PSCustomObject bodies with a clear error at the call site.

Note the check must use the real `[System.Management.Automation.PSCustomObject]` class: inside `ValidateScript`, `$_` is PSObject-wrapped and the `[PSCustomObject]` accelerator aliases `[PSObject]`, which matches everything — there's a comment in the code so this doesn't get "simplified" back.

## Verification

Harness dot-sourcing the real function with auth stubbed and `Invoke-RestMethod` shadowed to echo the outgoing body:

```
PASS  single hashtable       sends: { "RowKey": "abc", "ScheduledTime": 1750000000 }
PASS  array of hashtables    sends: [ { "TenantId": "1" }, { "TenantId": "2" } ]
PASS  PSCustomObject         sends: { "Name": "job1" }
PASS  no -Body (default)     sends: {}
BLOCK int                    Body must be a hashtable/PSCustomObject or an array of them, got [Int32].
BLOCK JSON string            ...got [String].
BLOCK array w/ one string    ...got [String].
```